### PR TITLE
chore: skip PR on publish

### DIFF
--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -28,7 +28,7 @@ jobs:
           command: 'version-or-publish'
           createRelease: true
       - name: create pull request
-        id: cpr
+        if: steps.covector.outputs.command == 'version'
         uses: tauri-apps/create-pull-request@v2.8.0
         with:
           title: "Publish New Versions"


### PR DESCRIPTION
We were also accidentally creating an OUT= file on the publish sequence which would then cause a PR to be opened. We have added a new output that we can use to skip PR straight away unless it is the version command. This fixes the problem, but avoids the root issue of the OUT= file for now.