### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     outputs:
-      RELEASE_UPLOAD_ID: ${{ steps.create_release.outputs.upload_id }}
+      RELEASE_UPLOAD_ID: ${{ steps.create_release.outputs.id }}
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The `create-release` action doesn't output `upload_id`, but `id`.

Closes #41 