### PR TITLE
fix: broken asset release upload

### DIFF
--- a/.changes/upload-toString-breaks.md
+++ b/.changes/upload-toString-breaks.md
@@ -1,0 +1,5 @@
+---
+"action": patch
+---
+
+Uploaded assets break when `data` receives `fs.readFileSync(assetPath).toString()` even though types suggest it. Giving it a Buffer fixes the issue.

--- a/dist/main.js
+++ b/dist/main.js
@@ -50,7 +50,9 @@ function getPackageJson(root) {
 }
 function hasTauriDependency(root) {
     const packageJson = getPackageJson(root);
-    return packageJson && ((packageJson.dependencies && packageJson.dependencies.tauri) || ((packageJson.devDependencies && packageJson.devDependencies.tauri)));
+    return (packageJson &&
+        ((packageJson.dependencies && packageJson.dependencies.tauri) ||
+            (packageJson.devDependencies && packageJson.devDependencies.tauri)));
 }
 function usesYarn(root) {
     return fs_1.existsSync(path_1.join(root, 'yarn.lock'));
@@ -63,12 +65,12 @@ function execCommand(command, { cwd }) {
         shell: process.env.shell || true,
         windowsHide: true,
         stdio: 'inherit',
-        env: { FORCE_COLOR: '0' },
+        env: { FORCE_COLOR: '0' }
     }).then();
 }
 function buildProject(root, debug, { configPath, distPath, iconPath, npmScript }) {
     return __awaiter(this, void 0, void 0, function* () {
-        return new Promise((resolve) => {
+        return new Promise(resolve => {
             if (hasTauriDependency(root)) {
                 if (npmScript) {
                     resolve(usesYarn(root) ? `yarn ${npmScript}` : `npm run ${npmScript}`);
@@ -93,8 +95,12 @@ function buildProject(root, debug, { configPath, distPath, iconPath, npmScript }
             }
             else {
                 const packageJson = getPackageJson(root);
-                const appName = packageJson ? (packageJson.displayName || packageJson.name).replace(/ /g, '-') : 'app';
-                return execCommand(`${runner} init --ci --app-name ${appName}`, { cwd: root }).then(() => {
+                const appName = packageJson
+                    ? (packageJson.displayName || packageJson.name).replace(/ /g, '-')
+                    : 'app';
+                return execCommand(`${runner} init --ci --app-name ${appName}`, {
+                    cwd: root
+                }).then(() => {
                     const cargoManifest = toml_1.default.parse(fs_1.readFileSync(manifestPath).toString());
                     const version = packageJson ? packageJson.version : '0.1.0';
                     console.log(`Replacing cargo manifest options - package.version=${version}`);
@@ -106,7 +112,9 @@ function buildProject(root, debug, { configPath, distPath, iconPath, npmScript }
                         version
                     };
                     if (iconPath) {
-                        return execCommand(`${runner} icon --i ${path_1.join(root, iconPath)}`, { cwd: root }).then(() => app);
+                        return execCommand(`${runner} icon --i ${path_1.join(root, iconPath)}`, {
+                            cwd: root
+                        }).then(() => app);
                     }
                     return app;
                 });
@@ -123,7 +131,8 @@ function buildProject(root, debug, { configPath, distPath, iconPath, npmScript }
                 fs_1.writeFileSync(tauriConfPath, JSON.stringify(tauriConf));
             }
             const args = debug ? ['--debug'] : [];
-            return execCommand(`${app.runner} build` + (args.length ? ` ${args.join(' ')}` : ''), { cwd: root }).then(() => {
+            return execCommand(`${app.runner} build` + (args.length ? ` ${args.join(' ')}` : ''), { cwd: root })
+                .then(() => {
                 const appName = app.name;
                 const artifactsPath = path_1.join(root, `src-tauri/target/${debug ? 'debug' : 'release'}`);
                 switch (os_1.platform()) {
@@ -134,18 +143,21 @@ function buildProject(root, debug, { configPath, distPath, iconPath, npmScript }
                         ];
                     case 'win32':
                         return [
-                            path_1.join(artifactsPath, `bundle/msi/${appName}_${app.version}_${process.arch}.msi`),
+                            path_1.join(artifactsPath, `bundle/msi/${appName}_${app.version}_${process.arch}.msi`)
                         ];
                     default:
                         const arch = process.arch === 'x64'
                             ? 'amd64'
-                            : (process.arch === 'x32' ? 'i386' : process.arch);
+                            : process.arch === 'x32'
+                                ? 'i386'
+                                : process.arch;
                         return [
                             path_1.join(artifactsPath, `bundle/deb/${appName}_${app.version}_${arch}.deb`),
                             path_1.join(artifactsPath, `bundle/appimage/${appName}_${app.version}_${arch}.AppImage`)
                         ];
                 }
-            }).then(paths => paths.filter(p => fs_1.existsSync(p)));
+            })
+                .then(paths => paths.filter(p => fs_1.existsSync(p)));
         });
     });
 }
@@ -167,7 +179,12 @@ function run() {
             if (Boolean(tagName) !== Boolean(releaseName)) {
                 throw new Error('`tag` is required along with `releaseName` when creating a release.');
             }
-            const options = { configPath: fs_1.existsSync(configPath) ? configPath : null, distPath, iconPath, npmScript };
+            const options = {
+                configPath: fs_1.existsSync(configPath) ? configPath : null,
+                distPath,
+                iconPath,
+                npmScript
+            };
             const artifacts = yield buildProject(projectPath, false, options);
             if (includeDebug) {
                 const debugArtifacts = yield buildProject(projectPath, true, options);
@@ -180,10 +197,12 @@ function run() {
             let releaseId;
             if (tagName) {
                 const packageJson = getPackageJson(projectPath);
-                const templates = [{
+                const templates = [
+                    {
                         key: '__VERSION__',
                         value: packageJson === null || packageJson === void 0 ? void 0 : packageJson.version
-                    }];
+                    }
+                ];
                 templates.forEach(template => {
                     const regex = new RegExp(template.key, 'g');
                     tagName = tagName.replace(regex, template.value);
@@ -204,7 +223,9 @@ function run() {
                     let i = 0;
                     for (const artifact of artifacts) {
                         if (artifact.endsWith('.app')) {
-                            yield execCommand(`tar -czf ${artifact}.tgz ${artifact}`, { cwd: undefined });
+                            yield execCommand(`tar -czf ${artifact}.tgz ${artifact}`, {
+                                cwd: undefined
+                            });
                             artifacts[i] += '.tgz';
                         }
                         i++;
@@ -214,6 +235,7 @@ function run() {
             }
         }
         catch (error) {
+            console.log('this');
             core.setFailed(error.message);
         }
     });

--- a/dist/upload-release-assets.js
+++ b/dist/upload-release-assets.js
@@ -24,15 +24,21 @@ function uploadAssets(releaseId, assets) {
         // Determine content-length for header to upload asset
         const contentLength = (filePath) => fs_1.default.statSync(filePath).size;
         for (const assetPath of assets) {
-            const headers = { 'content-type': 'application/zip', 'content-length': contentLength(assetPath) };
+            const headers = {
+                'content-type': 'application/zip',
+                'content-length': contentLength(assetPath)
+            };
             const ext = path_1.default.extname(assetPath);
             const filename = path_1.default.basename(assetPath).replace(ext, '');
-            const assetName = path_1.default.dirname(assetPath).includes(`target${path_1.default.sep}debug`) ? `${filename}-debug${ext}` : `${filename}${ext}`;
+            const assetName = path_1.default.dirname(assetPath).includes(`target${path_1.default.sep}debug`)
+                ? `${filename}-debug${ext}`
+                : `${filename}${ext}`;
             console.log(`Uploading ${assetName}...`);
             yield github.repos.uploadReleaseAsset({
                 headers,
                 name: assetName,
-                data: fs_1.default.readFileSync(assetPath).toString(),
+                // @ts-ignore error TS2322: Type 'Buffer' is not assignable to type 'string'.
+                data: fs_1.default.readFileSync(assetPath),
                 owner: github_1.context.repo.owner,
                 repo: github_1.context.repo.repo,
                 release_id: releaseId

--- a/src/create-release.ts
+++ b/src/create-release.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core'
-import { getOctokit, context } from '@actions/github'
-import { GitHub } from '@actions/github/lib/utils'
+import {getOctokit, context} from '@actions/github'
+import {GitHub} from '@actions/github/lib/utils'
 import fs from 'fs'
 
 interface Release {
@@ -18,14 +18,23 @@ interface GitHubRelease {
   target_commitish: string
 }
 
-function allReleases(github: InstanceType<typeof GitHub>): AsyncIterableIterator<{ data: GitHubRelease[] }> {
-  const params = { per_page: 100, ...context.repo }
+function allReleases(
+  github: InstanceType<typeof GitHub>
+): AsyncIterableIterator<{data: GitHubRelease[]}> {
+  const params = {per_page: 100, ...context.repo}
   return github.paginate.iterator(
     github.repos.listReleases.endpoint.merge(params)
-  );
+  )
 }
 
-export default async function createRelease(tagName: string, releaseName: string, body?: string, commitish?: string, draft = true, prerelease = true): Promise<Release> {
+export default async function createRelease(
+  tagName: string,
+  releaseName: string,
+  body?: string,
+  commitish?: string,
+  draft = true,
+  prerelease = true
+): Promise<Release> {
   if (process.env.GITHUB_TOKEN === undefined) {
     throw new Error('GITHUB_TOKEN is required')
   }
@@ -34,13 +43,13 @@ export default async function createRelease(tagName: string, releaseName: string
   const github = getOctokit(process.env.GITHUB_TOKEN)
 
   // Get owner and repo from context of payload that triggered the action
-  const { owner, repo } = context.repo
+  const {owner, repo} = context.repo
 
-  const bodyPath = core.getInput('body_path', { required: false })
+  const bodyPath = core.getInput('body_path', {required: false})
   let bodyFileContent = null
   if (bodyPath !== '' && !!bodyPath) {
     try {
-      bodyFileContent = fs.readFileSync(bodyPath, { encoding: 'utf8' })
+      bodyFileContent = fs.readFileSync(bodyPath, {encoding: 'utf8'})
     } catch (error) {
       core.setFailed(error.message)
     }
@@ -53,10 +62,14 @@ export default async function createRelease(tagName: string, releaseName: string
     if (draft) {
       console.log(`Looking for a draft release with tag ${tagName}...`)
       for await (const response of allReleases(github)) {
-        let releaseWithTag = response.data.find(release => release.tag_name === tagName)
+        let releaseWithTag = response.data.find(
+          release => release.tag_name === tagName
+        )
         if (releaseWithTag) {
           release = releaseWithTag
-          console.log(`Found draft release with tag ${tagName} on the release list.`)
+          console.log(
+            `Found draft release with tag ${tagName} on the release list.`
+          )
           break
         }
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,8 @@
-import { platform } from 'os'
+import {platform} from 'os'
 import * as core from '@actions/core'
 import execa from 'execa'
-import { join, resolve } from 'path'
-import { readFileSync, existsSync, copyFileSync, writeFileSync } from 'fs'
+import {join, resolve} from 'path'
+import {readFileSync, existsSync, copyFileSync, writeFileSync} from 'fs'
 import uploadReleaseAssets from './upload-release-assets'
 import createRelease from './create-release'
 import toml from '@iarna/toml'
@@ -19,14 +19,21 @@ function getPackageJson(root: string): any {
 
 function hasTauriDependency(root: string): boolean {
   const packageJson = getPackageJson(root)
-  return packageJson && ((packageJson.dependencies && packageJson.dependencies.tauri) || ((packageJson.devDependencies && packageJson.devDependencies.tauri)))
+  return (
+    packageJson &&
+    ((packageJson.dependencies && packageJson.dependencies.tauri) ||
+      (packageJson.devDependencies && packageJson.devDependencies.tauri))
+  )
 }
 
 function usesYarn(root: string): boolean {
   return existsSync(join(root, 'yarn.lock'))
 }
 
-function execCommand(command: string, { cwd }: { cwd: string | undefined }): Promise<void> {
+function execCommand(
+  command: string,
+  {cwd}: {cwd: string | undefined}
+): Promise<void> {
   console.log(`running ${command}`)
   const [cmd, ...args] = command.split(' ')
   return execa(cmd, args, {
@@ -34,7 +41,7 @@ function execCommand(command: string, { cwd }: { cwd: string | undefined }): Pro
     shell: process.env.shell || true,
     windowsHide: true,
     stdio: 'inherit',
-    env: { FORCE_COLOR: '0' },
+    env: {FORCE_COLOR: '0'}
   }).then()
 }
 
@@ -43,7 +50,7 @@ interface CargoManifestBin {
 }
 
 interface CargoManifest {
-  package: { version: string, name: string, 'default-run': string }
+  package: {version: string; name: string; 'default-run': string}
   bin: CargoManifestBin[]
 }
 
@@ -60,8 +67,12 @@ interface BuildOptions {
   npmScript: string | null
 }
 
-async function buildProject(root: string, debug: boolean, { configPath, distPath, iconPath, npmScript }: BuildOptions): Promise<string[]> {
-  return new Promise<string>((resolve) => {
+async function buildProject(
+  root: string,
+  debug: boolean,
+  {configPath, distPath, iconPath, npmScript}: BuildOptions
+): Promise<string[]> {
+  return new Promise<string>(resolve => {
     if (hasTauriDependency(root)) {
       if (npmScript) {
         resolve(usesYarn(root) ? `yarn ${npmScript}` : `npm run ${npmScript}`)
@@ -69,13 +80,17 @@ async function buildProject(root: string, debug: boolean, { configPath, distPath
         resolve(usesYarn(root) ? 'yarn tauri' : 'npx tauri')
       }
     } else {
-      execCommand('npm install -g tauri', { cwd: undefined }).then(() => resolve('tauri'))
+      execCommand('npm install -g tauri', {cwd: undefined}).then(() =>
+        resolve('tauri')
+      )
     }
   })
     .then((runner: string) => {
       const manifestPath = join(root, 'src-tauri/Cargo.toml')
       if (existsSync(manifestPath)) {
-        const cargoManifest = toml.parse(readFileSync(manifestPath).toString()) as any as CargoManifest
+        const cargoManifest = (toml.parse(
+          readFileSync(manifestPath).toString()
+        ) as any) as CargoManifest
         return {
           runner,
           name: cargoManifest.package.name,
@@ -83,12 +98,20 @@ async function buildProject(root: string, debug: boolean, { configPath, distPath
         }
       } else {
         const packageJson = getPackageJson(root)
-        const appName = packageJson ? (packageJson.displayName || packageJson.name).replace(/ /g, '-') : 'app'
-        return execCommand(`${runner} init --ci --app-name ${appName}`, { cwd: root }).then(() => {
-          const cargoManifest = toml.parse(readFileSync(manifestPath).toString()) as any as CargoManifest
+        const appName = packageJson
+          ? (packageJson.displayName || packageJson.name).replace(/ /g, '-')
+          : 'app'
+        return execCommand(`${runner} init --ci --app-name ${appName}`, {
+          cwd: root
+        }).then(() => {
+          const cargoManifest = (toml.parse(
+            readFileSync(manifestPath).toString()
+          ) as any) as CargoManifest
           const version = packageJson ? packageJson.version : '0.1.0'
 
-          console.log(`Replacing cargo manifest options - package.version=${version}`)
+          console.log(
+            `Replacing cargo manifest options - package.version=${version}`
+          )
           cargoManifest.package.version = version
           writeFileSync(manifestPath, toml.stringify(cargoManifest as any))
 
@@ -98,7 +121,9 @@ async function buildProject(root: string, debug: boolean, { configPath, distPath
             version
           }
           if (iconPath) {
-            return execCommand(`${runner} icon --i ${join(root, iconPath)}`, { cwd: root }).then(() => app)
+            return execCommand(`${runner} icon --i ${join(root, iconPath)}`, {
+              cwd: root
+            }).then(() => app)
           }
 
           return app
@@ -118,37 +143,69 @@ async function buildProject(root: string, debug: boolean, { configPath, distPath
       }
 
       const args = debug ? ['--debug'] : []
-      return execCommand(`${app.runner} build` + (args.length ? ` ${args.join(' ')}` : ''), { cwd: root }).then(() => {
-        const appName = app.name
-        const artifactsPath = join(root, `src-tauri/target/${debug ? 'debug' : 'release'}`)
+      return execCommand(
+        `${app.runner} build` + (args.length ? ` ${args.join(' ')}` : ''),
+        {cwd: root}
+      )
+        .then(() => {
+          const appName = app.name
+          const artifactsPath = join(
+            root,
+            `src-tauri/target/${debug ? 'debug' : 'release'}`
+          )
 
-        switch (platform()) {
-          case 'darwin':
-            return [
-              join(artifactsPath, `bundle/dmg/${appName}_${app.version}_${process.arch}.dmg`),
-              join(artifactsPath, `bundle/osx/${appName}_${app.version}_${process.arch}.app`)
-            ]
-          case 'win32':
-            return [
-              join(artifactsPath, `bundle/msi/${appName}_${app.version}_${process.arch}.msi`),
-            ]
-          default:
-            const arch = process.arch === 'x64'
-              ? 'amd64'
-              : (process.arch === 'x32' ? 'i386' : process.arch)
-            return [
-              join(artifactsPath, `bundle/deb/${appName}_${app.version}_${arch}.deb`),
-              join(artifactsPath, `bundle/appimage/${appName}_${app.version}_${arch}.AppImage`)
-            ]
-        }
-      }).then(paths => paths.filter(p => existsSync(p)))
+          switch (platform()) {
+            case 'darwin':
+              return [
+                join(
+                  artifactsPath,
+                  `bundle/dmg/${appName}_${app.version}_${process.arch}.dmg`
+                ),
+                join(
+                  artifactsPath,
+                  `bundle/osx/${appName}_${app.version}_${process.arch}.app`
+                )
+              ]
+            case 'win32':
+              return [
+                join(
+                  artifactsPath,
+                  `bundle/msi/${appName}_${app.version}_${process.arch}.msi`
+                )
+              ]
+            default:
+              const arch =
+                process.arch === 'x64'
+                  ? 'amd64'
+                  : process.arch === 'x32'
+                  ? 'i386'
+                  : process.arch
+              return [
+                join(
+                  artifactsPath,
+                  `bundle/deb/${appName}_${app.version}_${arch}.deb`
+                ),
+                join(
+                  artifactsPath,
+                  `bundle/appimage/${appName}_${app.version}_${arch}.AppImage`
+                )
+              ]
+          }
+        })
+        .then(paths => paths.filter(p => existsSync(p)))
     })
 }
 
 async function run(): Promise<void> {
   try {
-    const projectPath = resolve(process.cwd(), core.getInput('projectPath') || process.argv[2])
-    const configPath = join(projectPath, core.getInput('configPath') || 'tauri.conf.json')
+    const projectPath = resolve(
+      process.cwd(),
+      core.getInput('projectPath') || process.argv[2]
+    )
+    const configPath = join(
+      projectPath,
+      core.getInput('configPath') || 'tauri.conf.json'
+    )
     const distPath = core.getInput('distPath')
     const iconPath = core.getInput('iconPath')
     const includeDebug = core.getInput('includeDebug') === 'true'
@@ -162,10 +219,17 @@ async function run(): Promise<void> {
     const commitish = core.getInput('releaseCommitish') || null
 
     if (Boolean(tagName) !== Boolean(releaseName)) {
-      throw new Error('`tag` is required along with `releaseName` when creating a release.')
+      throw new Error(
+        '`tag` is required along with `releaseName` when creating a release.'
+      )
     }
 
-    const options: BuildOptions = { configPath: existsSync(configPath) ? configPath : null, distPath, iconPath, npmScript }
+    const options: BuildOptions = {
+      configPath: existsSync(configPath) ? configPath : null,
+      distPath,
+      iconPath,
+      npmScript
+    }
     const artifacts = await buildProject(projectPath, false, options)
     if (includeDebug) {
       const debugArtifacts = await buildProject(projectPath, true, options)
@@ -181,10 +245,12 @@ async function run(): Promise<void> {
     let releaseId: number
     if (tagName) {
       const packageJson = getPackageJson(projectPath)
-      const templates = [{
-        key: '__VERSION__',
-        value: packageJson?.version
-      }]
+      const templates = [
+        {
+          key: '__VERSION__',
+          value: packageJson?.version
+        }
+      ]
 
       templates.forEach(template => {
         const regex = new RegExp(template.key, 'g')
@@ -193,7 +259,14 @@ async function run(): Promise<void> {
         body = body.replace(regex, template.value)
       })
 
-      const releaseData = await createRelease(tagName, releaseName, body, commitish || undefined, draft, prerelease)
+      const releaseData = await createRelease(
+        tagName,
+        releaseName,
+        body,
+        commitish || undefined,
+        draft,
+        prerelease
+      )
       releaseId = releaseData.id
       core.setOutput('releaseUploadUrl', releaseData.uploadUrl)
       core.setOutput('releaseId', releaseData.id)
@@ -207,7 +280,9 @@ async function run(): Promise<void> {
         let i = 0
         for (const artifact of artifacts) {
           if (artifact.endsWith('.app')) {
-            await execCommand(`tar -czf ${artifact}.tgz ${artifact}`, { cwd: undefined })
+            await execCommand(`tar -czf ${artifact}.tgz ${artifact}`, {
+              cwd: undefined
+            })
             artifacts[i] += '.tgz'
           }
           i++
@@ -216,6 +291,7 @@ async function run(): Promise<void> {
       await uploadReleaseAssets(releaseId, artifacts)
     }
   } catch (error) {
+    console.log('this')
     core.setFailed(error.message)
   }
 }

--- a/src/upload-release-assets.ts
+++ b/src/upload-release-assets.ts
@@ -22,7 +22,8 @@ export default async function uploadAssets(releaseId: number, assets: string[]) 
     await github.repos.uploadReleaseAsset({
       headers,
       name: assetName,
-      data: fs.readFileSync(assetPath).toString(),
+      // @ts-ignore error TS2322: Type 'Buffer' is not assignable to type 'string'.
+      data: fs.readFileSync(assetPath),
       owner: context.repo.owner,
       repo: context.repo.repo,
       release_id: releaseId

--- a/src/upload-release-assets.ts
+++ b/src/upload-release-assets.ts
@@ -1,8 +1,11 @@
-import { getOctokit, context } from '@actions/github'
+import {getOctokit, context} from '@actions/github'
 import fs from 'fs'
 import path from 'path'
 
-export default async function uploadAssets(releaseId: number, assets: string[]) {
+export default async function uploadAssets(
+  releaseId: number,
+  assets: string[]
+) {
   if (process.env.GITHUB_TOKEN === undefined) {
     throw new Error('GITHUB_TOKEN is required')
   }
@@ -13,11 +16,16 @@ export default async function uploadAssets(releaseId: number, assets: string[]) 
   const contentLength = (filePath: string) => fs.statSync(filePath).size
 
   for (const assetPath of assets) {
-    const headers = { 'content-type': 'application/zip', 'content-length': contentLength(assetPath) }
+    const headers = {
+      'content-type': 'application/zip',
+      'content-length': contentLength(assetPath)
+    }
 
     const ext = path.extname(assetPath)
     const filename = path.basename(assetPath).replace(ext, '')
-    const assetName = path.dirname(assetPath).includes(`target${path.sep}debug`) ? `${filename}-debug${ext}` : `${filename}${ext}`
+    const assetName = path.dirname(assetPath).includes(`target${path.sep}debug`)
+      ? `${filename}-debug${ext}`
+      : `${filename}${ext}`
     console.log(`Uploading ${assetName}...`)
     await github.repos.uploadReleaseAsset({
       headers,

--- a/src/upload-release-assets.ts
+++ b/src/upload-release-assets.ts
@@ -30,6 +30,7 @@ export default async function uploadAssets(
     await github.repos.uploadReleaseAsset({
       headers,
       name: assetName,
+      // https://github.com/tauri-apps/tauri-action/pull/45
       // @ts-ignore error TS2322: Type 'Buffer' is not assignable to type 'string'.
       data: fs.readFileSync(assetPath),
       owner: context.repo.owner,


### PR DESCRIPTION
Uploaded assets break when `data` receives `fs.readFileSync(assetPath).toString()` even though types suggest it. Giving it a Buffer fixes the issue.