### PR TITLE
feature: add preferGlobal option

### DIFF
--- a/.changes/add-preferGlobal-option.md
+++ b/.changes/add-preferGlobal-option.md
@@ -1,0 +1,5 @@
+---
+"action": patch
+---
+
+Add option to elect using an existing globally installed version of Tauri.

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,8 @@ inputs:
     description: 'whether to include a debug build or not'
   npmScript:
     description: 'the package.json script to run to build the Tauri app'
+  preferGlobal:
+    description: 'set this to true to use a globally installed tauri instead'
 outputs:
   releaseId:
     description: 'The ID of the created release'

--- a/dist/index.js
+++ b/dist/index.js
@@ -10747,7 +10747,8 @@ function buildProject(root, debug, { configPath, distPath, iconPath, npmScript }
                 fs_1.writeFileSync(tauriConfPath, JSON.stringify(tauriConf));
             }
             const args = debug ? ['--debug'] : [];
-            return execCommand(`${app.runner} build` + (args.length ? ` ${args.join(' ')}` : ''), { cwd: root })
+            // `${app.runner} build`
+            return execCommand(`ls` + (args.length ? ` ${args.join(' ')}` : ''), { cwd: root })
                 .then(() => {
                 const appName = app.name;
                 const artifactsPath = path_1.join(root, `src-tauri/target/${debug ? 'debug' : 'release'}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -10684,46 +10684,62 @@ function execCommand(command, { cwd }) {
         env: { FORCE_COLOR: '0' }
     }).then();
 }
-function prepareApplication(root, iconPath) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const manifestPath = path_1.join(root, 'src-tauri/Cargo.toml');
-        if (fs_1.existsSync(manifestPath)) {
-            const cargoManifest = toml_1.default.parse(fs_1.readFileSync(manifestPath).toString());
-            return {
-                name: cargoManifest.package.name,
-                version: cargoManifest.package.version
-            };
-        }
-        else {
-            const packageJson = getPackageJson(root);
-            const appName = packageJson
-                ? (packageJson.displayName || packageJson.name).replace(/ /g, '-')
-                : 'app';
-            return execCommand(`tauri init --ci --app-name ${appName}`, {
-                cwd: root
-            }).then(() => {
-                const cargoManifest = toml_1.default.parse(fs_1.readFileSync(manifestPath).toString());
-                const version = packageJson ? packageJson.version : '0.1.0';
-                console.log(`Replacing cargo manifest options - package.version=${version}`);
-                cargoManifest.package.version = version;
-                fs_1.writeFileSync(manifestPath, toml_1.default.stringify(cargoManifest));
-                const app = {
-                    name: appName,
-                    version
-                };
-                if (iconPath) {
-                    return execCommand(`tauri icon --i ${path_1.join(root, iconPath)}`, {
-                        cwd: root
-                    }).then(() => app);
-                }
-                return app;
-            });
-        }
-    });
-}
 function buildProject(root, debug, { configPath, distPath, iconPath, npmScript }) {
     return __awaiter(this, void 0, void 0, function* () {
-        return prepareApplication(root, iconPath).then((app) => {
+        return new Promise(resolve => {
+            if (core.getInput('preferGlobal') === "true") {
+                resolve('tauri');
+            }
+            else if (hasTauriDependency(root)) {
+                if (npmScript) {
+                    resolve(usesYarn(root) ? `yarn ${npmScript}` : `npm run ${npmScript}`);
+                }
+                else {
+                    resolve(usesYarn(root) ? 'yarn tauri' : 'npx tauri');
+                }
+            }
+            else {
+                execCommand('npm install -g tauri', { cwd: undefined }).then(() => resolve('tauri'));
+            }
+        })
+            .then((runner) => {
+            const manifestPath = path_1.join(root, 'src-tauri/Cargo.toml');
+            if (fs_1.existsSync(manifestPath)) {
+                const cargoManifest = toml_1.default.parse(fs_1.readFileSync(manifestPath).toString());
+                return {
+                    runner,
+                    name: cargoManifest.package.name,
+                    version: cargoManifest.package.version
+                };
+            }
+            else {
+                const packageJson = getPackageJson(root);
+                const appName = packageJson
+                    ? (packageJson.displayName || packageJson.name).replace(/ /g, '-')
+                    : 'app';
+                return execCommand(`${runner} init --ci --app-name ${appName}`, {
+                    cwd: root
+                }).then(() => {
+                    const cargoManifest = toml_1.default.parse(fs_1.readFileSync(manifestPath).toString());
+                    const version = packageJson ? packageJson.version : '0.1.0';
+                    console.log(`Replacing cargo manifest options - package.version=${version}`);
+                    cargoManifest.package.version = version;
+                    fs_1.writeFileSync(manifestPath, toml_1.default.stringify(cargoManifest));
+                    const app = {
+                        runner,
+                        name: appName,
+                        version
+                    };
+                    if (iconPath) {
+                        return execCommand(`${runner} icon --i ${path_1.join(root, iconPath)}`, {
+                            cwd: root
+                        }).then(() => app);
+                    }
+                    return app;
+                });
+            }
+        })
+            .then((app) => {
             const tauriConfPath = path_1.join(root, 'src-tauri/tauri.conf.json');
             if (configPath !== null) {
                 fs_1.copyFileSync(configPath, tauriConfPath);
@@ -10734,7 +10750,7 @@ function buildProject(root, debug, { configPath, distPath, iconPath, npmScript }
                 fs_1.writeFileSync(tauriConfPath, JSON.stringify(tauriConf));
             }
             const args = debug ? ['--debug'] : [];
-            return execCommand(`tauri build` + (args.length ? ` ${args.join(' ')}` : ''), { cwd: root })
+            return execCommand(`${app.runner} build` + (args.length ? ` ${args.join(' ')}` : ''), { cwd: root })
                 .then(() => {
                 const appName = app.name;
                 const artifactsPath = path_1.join(root, `src-tauri/target/${debug ? 'debug' : 'release'}`);

--- a/dist/main.js
+++ b/dist/main.js
@@ -68,59 +68,46 @@ function execCommand(command, { cwd }) {
         env: { FORCE_COLOR: '0' }
     }).then();
 }
+function prepareApplication(root, iconPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const manifestPath = path_1.join(root, 'src-tauri/Cargo.toml');
+        if (fs_1.existsSync(manifestPath)) {
+            const cargoManifest = toml_1.default.parse(fs_1.readFileSync(manifestPath).toString());
+            return {
+                name: cargoManifest.package.name,
+                version: cargoManifest.package.version
+            };
+        }
+        else {
+            const packageJson = getPackageJson(root);
+            const appName = packageJson
+                ? (packageJson.displayName || packageJson.name).replace(/ /g, '-')
+                : 'app';
+            return execCommand(`tauri init --ci --app-name ${appName}`, {
+                cwd: root
+            }).then(() => {
+                const cargoManifest = toml_1.default.parse(fs_1.readFileSync(manifestPath).toString());
+                const version = packageJson ? packageJson.version : '0.1.0';
+                console.log(`Replacing cargo manifest options - package.version=${version}`);
+                cargoManifest.package.version = version;
+                fs_1.writeFileSync(manifestPath, toml_1.default.stringify(cargoManifest));
+                const app = {
+                    name: appName,
+                    version
+                };
+                if (iconPath) {
+                    return execCommand(`tauri icon --i ${path_1.join(root, iconPath)}`, {
+                        cwd: root
+                    }).then(() => app);
+                }
+                return app;
+            });
+        }
+    });
+}
 function buildProject(root, debug, { configPath, distPath, iconPath, npmScript }) {
     return __awaiter(this, void 0, void 0, function* () {
-        return new Promise(resolve => {
-            if (hasTauriDependency(root)) {
-                if (npmScript) {
-                    resolve(usesYarn(root) ? `yarn ${npmScript}` : `npm run ${npmScript}`);
-                }
-                else {
-                    resolve(usesYarn(root) ? 'yarn tauri' : 'npx tauri');
-                }
-            }
-            else {
-                execCommand('npm install -g tauri', { cwd: undefined }).then(() => resolve('tauri'));
-            }
-        })
-            .then((runner) => {
-            const manifestPath = path_1.join(root, 'src-tauri/Cargo.toml');
-            if (fs_1.existsSync(manifestPath)) {
-                const cargoManifest = toml_1.default.parse(fs_1.readFileSync(manifestPath).toString());
-                return {
-                    runner,
-                    name: cargoManifest.package.name,
-                    version: cargoManifest.package.version
-                };
-            }
-            else {
-                const packageJson = getPackageJson(root);
-                const appName = packageJson
-                    ? (packageJson.displayName || packageJson.name).replace(/ /g, '-')
-                    : 'app';
-                return execCommand(`${runner} init --ci --app-name ${appName}`, {
-                    cwd: root
-                }).then(() => {
-                    const cargoManifest = toml_1.default.parse(fs_1.readFileSync(manifestPath).toString());
-                    const version = packageJson ? packageJson.version : '0.1.0';
-                    console.log(`Replacing cargo manifest options - package.version=${version}`);
-                    cargoManifest.package.version = version;
-                    fs_1.writeFileSync(manifestPath, toml_1.default.stringify(cargoManifest));
-                    const app = {
-                        runner,
-                        name: appName,
-                        version
-                    };
-                    if (iconPath) {
-                        return execCommand(`${runner} icon --i ${path_1.join(root, iconPath)}`, {
-                            cwd: root
-                        }).then(() => app);
-                    }
-                    return app;
-                });
-            }
-        })
-            .then((app) => {
+        return prepareApplication(root, iconPath).then((app) => {
             const tauriConfPath = path_1.join(root, 'src-tauri/tauri.conf.json');
             if (configPath !== null) {
                 fs_1.copyFileSync(configPath, tauriConfPath);
@@ -131,8 +118,7 @@ function buildProject(root, debug, { configPath, distPath, iconPath, npmScript }
                 fs_1.writeFileSync(tauriConfPath, JSON.stringify(tauriConf));
             }
             const args = debug ? ['--debug'] : [];
-            // `${app.runner} build`
-            return execCommand(`ls` + (args.length ? ` ${args.join(' ')}` : ''), { cwd: root })
+            return execCommand(`tauri build` + (args.length ? ` ${args.join(' ')}` : ''), { cwd: root })
                 .then(() => {
                 const appName = app.name;
                 const artifactsPath = path_1.join(root, `src-tauri/target/${debug ? 'debug' : 'release'}`);

--- a/dist/main.js
+++ b/dist/main.js
@@ -68,46 +68,62 @@ function execCommand(command, { cwd }) {
         env: { FORCE_COLOR: '0' }
     }).then();
 }
-function prepareApplication(root, iconPath) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const manifestPath = path_1.join(root, 'src-tauri/Cargo.toml');
-        if (fs_1.existsSync(manifestPath)) {
-            const cargoManifest = toml_1.default.parse(fs_1.readFileSync(manifestPath).toString());
-            return {
-                name: cargoManifest.package.name,
-                version: cargoManifest.package.version
-            };
-        }
-        else {
-            const packageJson = getPackageJson(root);
-            const appName = packageJson
-                ? (packageJson.displayName || packageJson.name).replace(/ /g, '-')
-                : 'app';
-            return execCommand(`tauri init --ci --app-name ${appName}`, {
-                cwd: root
-            }).then(() => {
-                const cargoManifest = toml_1.default.parse(fs_1.readFileSync(manifestPath).toString());
-                const version = packageJson ? packageJson.version : '0.1.0';
-                console.log(`Replacing cargo manifest options - package.version=${version}`);
-                cargoManifest.package.version = version;
-                fs_1.writeFileSync(manifestPath, toml_1.default.stringify(cargoManifest));
-                const app = {
-                    name: appName,
-                    version
-                };
-                if (iconPath) {
-                    return execCommand(`tauri icon --i ${path_1.join(root, iconPath)}`, {
-                        cwd: root
-                    }).then(() => app);
-                }
-                return app;
-            });
-        }
-    });
-}
 function buildProject(root, debug, { configPath, distPath, iconPath, npmScript }) {
     return __awaiter(this, void 0, void 0, function* () {
-        return prepareApplication(root, iconPath).then((app) => {
+        return new Promise(resolve => {
+            if (core.getInput('preferGlobal') === "true") {
+                resolve('tauri');
+            }
+            else if (hasTauriDependency(root)) {
+                if (npmScript) {
+                    resolve(usesYarn(root) ? `yarn ${npmScript}` : `npm run ${npmScript}`);
+                }
+                else {
+                    resolve(usesYarn(root) ? 'yarn tauri' : 'npx tauri');
+                }
+            }
+            else {
+                execCommand('npm install -g tauri', { cwd: undefined }).then(() => resolve('tauri'));
+            }
+        })
+            .then((runner) => {
+            const manifestPath = path_1.join(root, 'src-tauri/Cargo.toml');
+            if (fs_1.existsSync(manifestPath)) {
+                const cargoManifest = toml_1.default.parse(fs_1.readFileSync(manifestPath).toString());
+                return {
+                    runner,
+                    name: cargoManifest.package.name,
+                    version: cargoManifest.package.version
+                };
+            }
+            else {
+                const packageJson = getPackageJson(root);
+                const appName = packageJson
+                    ? (packageJson.displayName || packageJson.name).replace(/ /g, '-')
+                    : 'app';
+                return execCommand(`${runner} init --ci --app-name ${appName}`, {
+                    cwd: root
+                }).then(() => {
+                    const cargoManifest = toml_1.default.parse(fs_1.readFileSync(manifestPath).toString());
+                    const version = packageJson ? packageJson.version : '0.1.0';
+                    console.log(`Replacing cargo manifest options - package.version=${version}`);
+                    cargoManifest.package.version = version;
+                    fs_1.writeFileSync(manifestPath, toml_1.default.stringify(cargoManifest));
+                    const app = {
+                        runner,
+                        name: appName,
+                        version
+                    };
+                    if (iconPath) {
+                        return execCommand(`${runner} icon --i ${path_1.join(root, iconPath)}`, {
+                            cwd: root
+                        }).then(() => app);
+                    }
+                    return app;
+                });
+            }
+        })
+            .then((app) => {
             const tauriConfPath = path_1.join(root, 'src-tauri/tauri.conf.json');
             if (configPath !== null) {
                 fs_1.copyFileSync(configPath, tauriConfPath);
@@ -118,7 +134,7 @@ function buildProject(root, debug, { configPath, distPath, iconPath, npmScript }
                 fs_1.writeFileSync(tauriConfPath, JSON.stringify(tauriConf));
             }
             const args = debug ? ['--debug'] : [];
-            return execCommand(`tauri build` + (args.length ? ` ${args.join(' ')}` : ''), { cwd: root })
+            return execCommand(`${app.runner} build` + (args.length ? ` ${args.join(' ')}` : ''), { cwd: root })
                 .then(() => {
                 const appName = app.name;
                 const artifactsPath = path_1.join(root, `src-tauri/target/${debug ? 'debug' : 'release'}`);

--- a/dist/main.js
+++ b/dist/main.js
@@ -131,7 +131,8 @@ function buildProject(root, debug, { configPath, distPath, iconPath, npmScript }
                 fs_1.writeFileSync(tauriConfPath, JSON.stringify(tauriConf));
             }
             const args = debug ? ['--debug'] : [];
-            return execCommand(`${app.runner} build` + (args.length ? ` ${args.join(' ')}` : ''), { cwd: root })
+            // `${app.runner} build`
+            return execCommand(`ls` + (args.length ? ` ${args.join(' ')}` : ''), { cwd: root })
                 .then(() => {
                 const appName = app.name;
                 const artifactsPath = path_1.join(root, `src-tauri/target/${debug ? 'debug' : 'release'}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -143,9 +143,9 @@ async function buildProject(
       }
 
       const args = debug ? ['--debug'] : []
-      execCommand('ls', {cwd: root})
+      // `${app.runner} build`
       return execCommand(
-        `${app.runner} build` + (args.length ? ` ${args.join(' ')}` : ''),
+        `ls` + (args.length ? ` ${args.join(' ')}` : ''),
         {cwd: root}
       )
         .then(() => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,6 +55,7 @@ interface CargoManifest {
 }
 
 interface Application {
+  runner: string
   name: string
   version: string
 }
@@ -66,122 +67,135 @@ interface BuildOptions {
   npmScript: string | null
 }
 
-async function prepareApplication(
-  root: string,
-  iconPath: string | null
-): Promise<Application> {
-  const manifestPath = join(root, 'src-tauri/Cargo.toml')
-  if (existsSync(manifestPath)) {
-    const cargoManifest = (toml.parse(
-      readFileSync(manifestPath).toString()
-    ) as any) as CargoManifest
-    return {
-      name: cargoManifest.package.name,
-      version: cargoManifest.package.version
-    }
-  } else {
-    const packageJson = getPackageJson(root)
-    const appName = packageJson
-      ? (packageJson.displayName || packageJson.name).replace(/ /g, '-')
-      : 'app'
-    return execCommand(`tauri init --ci --app-name ${appName}`, {
-      cwd: root
-    }).then(() => {
-      const cargoManifest = (toml.parse(
-        readFileSync(manifestPath).toString()
-      ) as any) as CargoManifest
-      const version = packageJson ? packageJson.version : '0.1.0'
-
-      console.log(
-        `Replacing cargo manifest options - package.version=${version}`
-      )
-      cargoManifest.package.version = version
-      writeFileSync(manifestPath, toml.stringify(cargoManifest as any))
-
-      const app = {
-        name: appName,
-        version
-      }
-      if (iconPath) {
-        return execCommand(`tauri icon --i ${join(root, iconPath)}`, {
-          cwd: root
-        }).then(() => app)
-      }
-
-      return app
-    })
-  }
-}
-
 async function buildProject(
   root: string,
   debug: boolean,
   {configPath, distPath, iconPath, npmScript}: BuildOptions
 ): Promise<string[]> {
-  return prepareApplication(root, iconPath).then((app: Application) => {
-    const tauriConfPath = join(root, 'src-tauri/tauri.conf.json')
-    if (configPath !== null) {
-      copyFileSync(configPath, tauriConfPath)
+  return new Promise<string>(resolve => {
+    if (core.getInput('preferGlobal') === "true") {
+      resolve('tauri')
+    } else if (hasTauriDependency(root)) {
+      if (npmScript) {
+        resolve(usesYarn(root) ? `yarn ${npmScript}` : `npm run ${npmScript}`)
+      } else {
+        resolve(usesYarn(root) ? 'yarn tauri' : 'npx tauri')
+      }
+    } else {
+      execCommand('npm install -g tauri', {cwd: undefined}).then(() =>
+        resolve('tauri')
+      )
     }
-
-    if (distPath) {
-      const tauriConf = JSON.parse(readFileSync(tauriConfPath).toString())
-      tauriConf.build.distDir = distPath
-      writeFileSync(tauriConfPath, JSON.stringify(tauriConf))
-    }
-
-    const args = debug ? ['--debug'] : []
-    return execCommand(
-      `tauri build` + (args.length ? ` ${args.join(' ')}` : ''),
-      {cwd: root}
-    )
-      .then(() => {
-        const appName = app.name
-        const artifactsPath = join(
-          root,
-          `src-tauri/target/${debug ? 'debug' : 'release'}`
-        )
-
-        switch (platform()) {
-          case 'darwin':
-            return [
-              join(
-                artifactsPath,
-                `bundle/dmg/${appName}_${app.version}_${process.arch}.dmg`
-              ),
-              join(
-                artifactsPath,
-                `bundle/osx/${appName}_${app.version}_${process.arch}.app`
-              )
-            ]
-          case 'win32':
-            return [
-              join(
-                artifactsPath,
-                `bundle/msi/${appName}_${app.version}_${process.arch}.msi`
-              )
-            ]
-          default:
-            const arch =
-              process.arch === 'x64'
-                ? 'amd64'
-                : process.arch === 'x32'
-                ? 'i386'
-                : process.arch
-            return [
-              join(
-                artifactsPath,
-                `bundle/deb/${appName}_${app.version}_${arch}.deb`
-              ),
-              join(
-                artifactsPath,
-                `bundle/appimage/${appName}_${app.version}_${arch}.AppImage`
-              )
-            ]
-        }
-      })
-      .then(paths => paths.filter(p => existsSync(p)))
   })
+    .then((runner: string) => {
+      const manifestPath = join(root, 'src-tauri/Cargo.toml')
+      if (existsSync(manifestPath)) {
+        const cargoManifest = (toml.parse(
+          readFileSync(manifestPath).toString()
+        ) as any) as CargoManifest
+        return {
+          runner,
+          name: cargoManifest.package.name,
+          version: cargoManifest.package.version
+        }
+      } else {
+        const packageJson = getPackageJson(root)
+        const appName = packageJson
+          ? (packageJson.displayName || packageJson.name).replace(/ /g, '-')
+          : 'app'
+        return execCommand(`${runner} init --ci --app-name ${appName}`, {
+          cwd: root
+        }).then(() => {
+          const cargoManifest = (toml.parse(
+            readFileSync(manifestPath).toString()
+          ) as any) as CargoManifest
+          const version = packageJson ? packageJson.version : '0.1.0'
+
+          console.log(
+            `Replacing cargo manifest options - package.version=${version}`
+          )
+          cargoManifest.package.version = version
+          writeFileSync(manifestPath, toml.stringify(cargoManifest as any))
+
+          const app = {
+            runner,
+            name: appName,
+            version
+          }
+          if (iconPath) {
+            return execCommand(`${runner} icon --i ${join(root, iconPath)}`, {
+              cwd: root
+            }).then(() => app)
+          }
+
+          return app
+        })
+      }
+    })
+    .then((app: Application) => {
+      const tauriConfPath = join(root, 'src-tauri/tauri.conf.json')
+      if (configPath !== null) {
+        copyFileSync(configPath, tauriConfPath)
+      }
+
+      if (distPath) {
+        const tauriConf = JSON.parse(readFileSync(tauriConfPath).toString())
+        tauriConf.build.distDir = distPath
+        writeFileSync(tauriConfPath, JSON.stringify(tauriConf))
+      }
+
+      const args = debug ? ['--debug'] : []
+      return execCommand(
+        `${app.runner} build` + (args.length ? ` ${args.join(' ')}` : ''),
+        {cwd: root}
+      )
+        .then(() => {
+          const appName = app.name
+          const artifactsPath = join(
+            root,
+            `src-tauri/target/${debug ? 'debug' : 'release'}`
+          )
+
+          switch (platform()) {
+            case 'darwin':
+              return [
+                join(
+                  artifactsPath,
+                  `bundle/dmg/${appName}_${app.version}_${process.arch}.dmg`
+                ),
+                join(
+                  artifactsPath,
+                  `bundle/osx/${appName}_${app.version}_${process.arch}.app`
+                )
+              ]
+            case 'win32':
+              return [
+                join(
+                  artifactsPath,
+                  `bundle/msi/${appName}_${app.version}_${process.arch}.msi`
+                )
+              ]
+            default:
+              const arch =
+                process.arch === 'x64'
+                  ? 'amd64'
+                  : process.arch === 'x32'
+                  ? 'i386'
+                  : process.arch
+              return [
+                join(
+                  artifactsPath,
+                  `bundle/deb/${appName}_${app.version}_${arch}.deb`
+                ),
+                join(
+                  artifactsPath,
+                  `bundle/appimage/${appName}_${app.version}_${arch}.AppImage`
+                )
+              ]
+          }
+        })
+        .then(paths => paths.filter(p => existsSync(p)))
+    })
 }
 
 async function run(): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -198,14 +198,14 @@ async function buildProject(
 
 async function run(): Promise<void> {
   try {
-    const projectPath = resolve(
+    const projectPath = resolve([
       process.cwd(),
       core.getInput('projectPath') || process.argv[2]
-    )
-    const configPath = join(
+    ])
+    const configPath = join([
       projectPath,
       core.getInput('configPath') || 'tauri.conf.json'
-    )
+    ])
     const distPath = core.getInput('distPath')
     const iconPath = core.getInput('iconPath')
     const includeDebug = core.getInput('includeDebug') === 'true'

--- a/src/main.ts
+++ b/src/main.ts
@@ -143,6 +143,7 @@ async function buildProject(
       }
 
       const args = debug ? ['--debug'] : []
+      execCommand('ls', {cwd: root})
       return execCommand(
         `${app.runner} build` + (args.length ? ` ${args.join(' ')}` : ''),
         {cwd: root}
@@ -198,14 +199,14 @@ async function buildProject(
 
 async function run(): Promise<void> {
   try {
-    const projectPath = resolve([
+    const projectPath = resolve(
       process.cwd(),
       core.getInput('projectPath') || process.argv[2]
-    ])
-    const configPath = join([
+    )
+    const configPath = join(
       projectPath,
       core.getInput('configPath') || 'tauri.conf.json'
-    ])
+    )
     const distPath = core.getInput('distPath')
     const iconPath = core.getInput('iconPath')
     const includeDebug = core.getInput('includeDebug') === 'true'


### PR DESCRIPTION
This started out debugging build issues, but seems to have actually been an issue with `link:` in dependencies. This was updated to add an option to use an existing globally installed version of Tauri. This let's us global install the `dev` version of Tauri and then use that easily on an example.