### PR TITLE
Trying to fix issue #31: AppImage file is not uploaded to release (only deb).

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,11 +1,11 @@
 name: 'tauri-action'
 description: 'Build tauri binaries for MacOS, Windows and Linux'
-icon: 'download-cloud'
+icon: 'box'
 color: 'blue'
-author: 'Lucas Nogueira <lucas@tauri.studio>'
+author: 'Laurent Bernabé <laurent.bernabe@gmail.com>'
 inputs:
   releaseId:
-    description: 'The id of the release to upload artifacts as release assets'
+    description: 'Github action for Tauri'
   tagName:
     description: 'The tag name of the release to create'
   releaseName:

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'tauri-action-loloof64'
+name: 'tauri-action'
 description: 'Build tauri binaries for MacOS, Windows and Linux'
 icon: 'box'
 color: 'blue'

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,8 @@ icon: 'box'
 color: 'blue'
 author: 'Laurent Bernabé <laurent.bernabe@gmail.com>'
 inputs:
+  icon: 'box'
+  color: 'blue'
   releaseId:
     description: 'Github action for Tauri'
   tagName:

--- a/action.yml
+++ b/action.yml
@@ -1,11 +1,9 @@
-name: 'tauri-action'
+name: 'tauri-action-loloof64'
 description: 'Build tauri binaries for MacOS, Windows and Linux'
 icon: 'box'
 color: 'blue'
 author: 'Laurent Bernabé <laurent.bernabe@gmail.com>'
 inputs:
-  icon: 'box'
-  color: 'blue'
   releaseId:
     description: 'Github action for Tauri'
   tagName:

--- a/dist/index.js
+++ b/dist/index.js
@@ -10770,9 +10770,12 @@ function buildProject(root, debug, { configPath, distPath, iconPath, npmScript }
                             : process.arch === 'x32'
                                 ? 'i386'
                                 : process.arch;
+                        const oldAppImagePath = path_1.join(artifactsPath, `bundle/appimage/${appName}.AppImage`);
+                        const newAppImagePath = path_1.join(artifactsPath, `bundle/appimage/${appName}_${app.version}_${arch}.AppImage`);
+                        fs_1.copyFileSync(oldAppImagePath, newAppImagePath);
                         return [
                             path_1.join(artifactsPath, `bundle/deb/${appName}_${app.version}_${arch}.deb`),
-                            path_1.join(artifactsPath, `bundle/appimage/${appName}_${app.version}_${arch}.AppImage`)
+                            newAppImagePath,
                         ];
                 }
             })

--- a/dist/index.js
+++ b/dist/index.js
@@ -10772,10 +10772,12 @@ function buildProject(root, debug, { configPath, distPath, iconPath, npmScript }
                                 : process.arch;
                         const oldAppImagePath = path_1.join(artifactsPath, `bundle/appimage/${appName}.AppImage`);
                         const newAppImagePath = path_1.join(artifactsPath, `bundle/appimage/${appName}_${app.version}_${arch}.AppImage`);
-                        fs_1.copyFileSync(oldAppImagePath, newAppImagePath);
                         //////////////////////////////////////////////////////////////////////
                         console.log('old app image path', oldAppImagePath);
                         console.log('new app image path', newAppImagePath);
+                        ////////////////////////////////////////////////////////////////////////////////////
+                        fs_1.copyFileSync(oldAppImagePath, newAppImagePath);
+                        ////////////////////////////////////////////////////////////////////////////////////  
                         console.log('new app image exists', fs_1.existsSync(newAppImagePath));
                         /////////////////////////////////////////////////////////////////////////
                         return [

--- a/dist/index.js
+++ b/dist/index.js
@@ -10772,21 +10772,13 @@ function buildProject(root, debug, { configPath, distPath, iconPath, npmScript }
                                 : process.arch;
                         const oldAppImagePath = path_1.join(artifactsPath, `bundle/appimage/${appName}.AppImage`);
                         const newAppImagePath = path_1.join(artifactsPath, `bundle/appimage/${appName}_${app.version}_${arch}.AppImage`);
-                        //////////////////////////////////////////////////////////////////////
-                        console.log('old app image path', oldAppImagePath);
-                        console.log('new app image path', newAppImagePath);
-                        ////////////////////////////////////////////////////////////////////////////////////
                         fs_1.copyFileSync(oldAppImagePath, newAppImagePath);
-                        ////////////////////////////////////////////////////////////////////////////////////  
-                        console.log('new app image exists', fs_1.existsSync(newAppImagePath));
-                        /////////////////////////////////////////////////////////////////////////
                         return [
                             path_1.join(artifactsPath, `bundle/deb/${appName}_${app.version}_${arch}.deb`),
                             newAppImagePath,
                         ];
                 }
-            })
-                .then(paths => paths.filter(p => fs_1.existsSync(p)));
+            });
         });
     });
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -10773,6 +10773,11 @@ function buildProject(root, debug, { configPath, distPath, iconPath, npmScript }
                         const oldAppImagePath = path_1.join(artifactsPath, `bundle/appimage/${appName}.AppImage`);
                         const newAppImagePath = path_1.join(artifactsPath, `bundle/appimage/${appName}_${app.version}_${arch}.AppImage`);
                         fs_1.copyFileSync(oldAppImagePath, newAppImagePath);
+                        //////////////////////////////////////////////////////////////////////
+                        console.log('old app image path', oldAppImagePath);
+                        console.log('new app image path', newAppImagePath);
+                        console.log('new app image exists', fs_1.existsSync(newAppImagePath));
+                        /////////////////////////////////////////////////////////////////////////
                         return [
                             path_1.join(artifactsPath, `bundle/deb/${appName}_${app.version}_${arch}.deb`),
                             newAppImagePath,

--- a/dist/main.js
+++ b/dist/main.js
@@ -156,10 +156,12 @@ function buildProject(root, debug, { configPath, distPath, iconPath, npmScript }
                                 : process.arch;
                         const oldAppImagePath = path_1.join(artifactsPath, `bundle/appimage/${appName}.AppImage`);
                         const newAppImagePath = path_1.join(artifactsPath, `bundle/appimage/${appName}_${app.version}_${arch}.AppImage`);
-                        fs_1.copyFileSync(oldAppImagePath, newAppImagePath);
                         //////////////////////////////////////////////////////////////////////
                         console.log('old app image path', oldAppImagePath);
                         console.log('new app image path', newAppImagePath);
+                        ////////////////////////////////////////////////////////////////////////////////////
+                        fs_1.copyFileSync(oldAppImagePath, newAppImagePath);
+                        ////////////////////////////////////////////////////////////////////////////////////  
                         console.log('new app image exists', fs_1.existsSync(newAppImagePath));
                         /////////////////////////////////////////////////////////////////////////
                         return [

--- a/dist/main.js
+++ b/dist/main.js
@@ -157,6 +157,11 @@ function buildProject(root, debug, { configPath, distPath, iconPath, npmScript }
                         const oldAppImagePath = path_1.join(artifactsPath, `bundle/appimage/${appName}.AppImage`);
                         const newAppImagePath = path_1.join(artifactsPath, `bundle/appimage/${appName}_${app.version}_${arch}.AppImage`);
                         fs_1.copyFileSync(oldAppImagePath, newAppImagePath);
+                        //////////////////////////////////////////////////////////////////////
+                        console.log('old app image path', oldAppImagePath);
+                        console.log('new app image path', newAppImagePath);
+                        console.log('new app image exists', fs_1.existsSync(newAppImagePath));
+                        /////////////////////////////////////////////////////////////////////////
                         return [
                             path_1.join(artifactsPath, `bundle/deb/${appName}_${app.version}_${arch}.deb`),
                             newAppImagePath,

--- a/dist/main.js
+++ b/dist/main.js
@@ -156,21 +156,13 @@ function buildProject(root, debug, { configPath, distPath, iconPath, npmScript }
                                 : process.arch;
                         const oldAppImagePath = path_1.join(artifactsPath, `bundle/appimage/${appName}.AppImage`);
                         const newAppImagePath = path_1.join(artifactsPath, `bundle/appimage/${appName}_${app.version}_${arch}.AppImage`);
-                        //////////////////////////////////////////////////////////////////////
-                        console.log('old app image path', oldAppImagePath);
-                        console.log('new app image path', newAppImagePath);
-                        ////////////////////////////////////////////////////////////////////////////////////
                         fs_1.copyFileSync(oldAppImagePath, newAppImagePath);
-                        ////////////////////////////////////////////////////////////////////////////////////  
-                        console.log('new app image exists', fs_1.existsSync(newAppImagePath));
-                        /////////////////////////////////////////////////////////////////////////
                         return [
                             path_1.join(artifactsPath, `bundle/deb/${appName}_${app.version}_${arch}.deb`),
                             newAppImagePath,
                         ];
                 }
-            })
-                .then(paths => paths.filter(p => fs_1.existsSync(p)));
+            });
         });
     });
 }

--- a/dist/main.js
+++ b/dist/main.js
@@ -154,9 +154,12 @@ function buildProject(root, debug, { configPath, distPath, iconPath, npmScript }
                             : process.arch === 'x32'
                                 ? 'i386'
                                 : process.arch;
+                        const oldAppImagePath = path_1.join(artifactsPath, `bundle/appimage/${appName}.AppImage`);
+                        const newAppImagePath = path_1.join(artifactsPath, `bundle/appimage/${appName}_${app.version}_${arch}.AppImage`);
+                        fs_1.copyFileSync(oldAppImagePath, newAppImagePath);
                         return [
                             path_1.join(artifactsPath, `bundle/deb/${appName}_${app.version}_${arch}.deb`),
-                            path_1.join(artifactsPath, `bundle/appimage/${appName}_${app.version}_${arch}.AppImage`)
+                            newAppImagePath,
                         ];
                 }
             })

--- a/src/main.ts
+++ b/src/main.ts
@@ -195,6 +195,12 @@ async function buildProject(
 
               copyFileSync(oldAppImagePath, newAppImagePath);
 
+              //////////////////////////////////////////////////////////////////////
+              console.log('old app image path', oldAppImagePath);
+              console.log('new app image path', newAppImagePath);
+              console.log('new app image exists', existsSync(newAppImagePath));
+              /////////////////////////////////////////////////////////////////////////
+
               return [
                 join(
                   artifactsPath,

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import { platform } from 'os'
 import * as core from '@actions/core'
 import execa from 'execa'
 import { join, resolve } from 'path'
-import { readFileSync, existsSync, copyFileSync, writeFileSync, renameFileSync } from 'fs'
+import { readFileSync, existsSync, copyFileSync, writeFileSync, renameSync } from 'fs'
 import uploadReleaseAssets from './upload-release-assets'
 import createRelease from './create-release'
 import toml from '@iarna/toml'
@@ -193,7 +193,7 @@ async function buildProject(
                 `bundle/appimage/${appName}_${app.version}_${arch}.AppImage`
               );
 
-              renameFileSync(oldAppImagePath, newAppImagePath);
+              renameSync(oldAppImagePath, newAppImagePath);
 
               return [
                 join(

--- a/src/main.ts
+++ b/src/main.ts
@@ -193,6 +193,11 @@ async function buildProject(
                 `bundle/appimage/${appName}_${app.version}_${arch}.AppImage`
               );
 
+              ///////////////////////////////////////////////
+              console.log('old path', oldAppImagePath);
+              console.log('new path', newAppImagePath)
+              ///////////////////////////////////////////////
+
               copyFileSync(oldAppImagePath, newAppImagePath);
 
               return [

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,8 @@
-import { platform } from 'os'
+import {platform} from 'os'
 import * as core from '@actions/core'
 import execa from 'execa'
-import { join, resolve } from 'path'
-import { readFileSync, existsSync, copyFileSync, writeFileSync } from 'fs'
+import {join, resolve} from 'path'
+import {readFileSync, existsSync, copyFileSync, writeFileSync} from 'fs'
 import uploadReleaseAssets from './upload-release-assets'
 import createRelease from './create-release'
 import toml from '@iarna/toml'
@@ -32,7 +32,7 @@ function usesYarn(root: string): boolean {
 
 function execCommand(
   command: string,
-  { cwd }: { cwd: string | undefined }
+  {cwd}: {cwd: string | undefined}
 ): Promise<void> {
   console.log(`running ${command}`)
   const [cmd, ...args] = command.split(' ')
@@ -41,7 +41,7 @@ function execCommand(
     shell: process.env.shell || true,
     windowsHide: true,
     stdio: 'inherit',
-    env: { FORCE_COLOR: '0' }
+    env: {FORCE_COLOR: '0'}
   }).then()
 }
 
@@ -50,7 +50,7 @@ interface CargoManifestBin {
 }
 
 interface CargoManifest {
-  package: { version: string; name: string; 'default-run': string }
+  package: {version: string; name: string; 'default-run': string}
   bin: CargoManifestBin[]
 }
 
@@ -70,7 +70,7 @@ interface BuildOptions {
 async function buildProject(
   root: string,
   debug: boolean,
-  { configPath, distPath, iconPath, npmScript }: BuildOptions
+  {configPath, distPath, iconPath, npmScript}: BuildOptions
 ): Promise<string[]> {
   return new Promise<string>(resolve => {
     if (core.getInput('preferGlobal') === "true") {
@@ -82,7 +82,7 @@ async function buildProject(
         resolve(usesYarn(root) ? 'yarn tauri' : 'npx tauri')
       }
     } else {
-      execCommand('npm install -g tauri', { cwd: undefined }).then(() =>
+      execCommand('npm install -g tauri', {cwd: undefined}).then(() =>
         resolve('tauri')
       )
     }
@@ -147,7 +147,7 @@ async function buildProject(
       const args = debug ? ['--debug'] : []
       return execCommand(
         `${app.runner} build` + (args.length ? ` ${args.join(' ')}` : ''),
-        { cwd: root }
+        {cwd: root}
       )
         .then(() => {
           const appName = app.name
@@ -180,32 +180,17 @@ async function buildProject(
                 process.arch === 'x64'
                   ? 'amd64'
                   : process.arch === 'x32'
-                    ? 'i386'
-                    : process.arch
-
-              const oldAppImagePath = join(
-                artifactsPath,
-                `bundle/appimage/${appName}.AppImage`
-              );
-
-              const newAppImagePath = join(
-                artifactsPath,
-                `bundle/appimage/${appName}_${app.version}_${arch}.AppImage`
-              );
-
-              ///////////////////////////////////////////////
-              console.log('old path', oldAppImagePath);
-              console.log('new path', newAppImagePath)
-              ///////////////////////////////////////////////
-
-              copyFileSync(oldAppImagePath, newAppImagePath);
-
+                  ? 'i386'
+                  : process.arch
               return [
                 join(
                   artifactsPath,
                   `bundle/deb/${appName}_${app.version}_${arch}.deb`
                 ),
-                newAppImagePath,
+                join(
+                  artifactsPath,
+                  `bundle/appimage/${appName}.AppImage`
+                )
               ]
           }
         })

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import { platform } from 'os'
 import * as core from '@actions/core'
 import execa from 'execa'
 import { join, resolve } from 'path'
-import { readFileSync, existsSync, copyFileSync, writeFileSync, renameSync } from 'fs'
+import { readFileSync, existsSync, copyFileSync, writeFileSync } from 'fs'
 import uploadReleaseAssets from './upload-release-assets'
 import createRelease from './create-release'
 import toml from '@iarna/toml'
@@ -193,7 +193,7 @@ async function buildProject(
                 `bundle/appimage/${appName}_${app.version}_${arch}.AppImage`
               );
 
-              renameSync(oldAppImagePath, newAppImagePath);
+              copyFileSync(oldAppImagePath, newAppImagePath);
 
               return [
                 join(

--- a/src/main.ts
+++ b/src/main.ts
@@ -192,17 +192,7 @@ async function buildProject(
                 artifactsPath,
                 `bundle/appimage/${appName}_${app.version}_${arch}.AppImage`
               );
-              //////////////////////////////////////////////////////////////////////
-              console.log('old app image path', oldAppImagePath);
-              console.log('new app image path', newAppImagePath);
-              ////////////////////////////////////////////////////////////////////////////////////
-
               copyFileSync(oldAppImagePath, newAppImagePath);
-
-              ////////////////////////////////////////////////////////////////////////////////////  
-              console.log('new app image exists', existsSync(newAppImagePath));
-              /////////////////////////////////////////////////////////////////////////
-
               return [
                 join(
                   artifactsPath,
@@ -211,8 +201,7 @@ async function buildProject(
                 newAppImagePath,
               ]
           }
-        })
-        .then(paths => paths.filter(p => existsSync(p)))
+        });
     })
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -192,12 +192,14 @@ async function buildProject(
                 artifactsPath,
                 `bundle/appimage/${appName}_${app.version}_${arch}.AppImage`
               );
-
-              copyFileSync(oldAppImagePath, newAppImagePath);
-
               //////////////////////////////////////////////////////////////////////
               console.log('old app image path', oldAppImagePath);
               console.log('new app image path', newAppImagePath);
+              ////////////////////////////////////////////////////////////////////////////////////
+
+              copyFileSync(oldAppImagePath, newAppImagePath);
+
+              ////////////////////////////////////////////////////////////////////////////////////  
               console.log('new app image exists', existsSync(newAppImagePath));
               /////////////////////////////////////////////////////////////////////////
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,8 @@
-import {platform} from 'os'
+import { platform } from 'os'
 import * as core from '@actions/core'
 import execa from 'execa'
-import {join, resolve} from 'path'
-import {readFileSync, existsSync, copyFileSync, writeFileSync} from 'fs'
+import { join, resolve } from 'path'
+import { readFileSync, existsSync, copyFileSync, writeFileSync, renameFileSync } from 'fs'
 import uploadReleaseAssets from './upload-release-assets'
 import createRelease from './create-release'
 import toml from '@iarna/toml'
@@ -32,7 +32,7 @@ function usesYarn(root: string): boolean {
 
 function execCommand(
   command: string,
-  {cwd}: {cwd: string | undefined}
+  { cwd }: { cwd: string | undefined }
 ): Promise<void> {
   console.log(`running ${command}`)
   const [cmd, ...args] = command.split(' ')
@@ -41,7 +41,7 @@ function execCommand(
     shell: process.env.shell || true,
     windowsHide: true,
     stdio: 'inherit',
-    env: {FORCE_COLOR: '0'}
+    env: { FORCE_COLOR: '0' }
   }).then()
 }
 
@@ -50,7 +50,7 @@ interface CargoManifestBin {
 }
 
 interface CargoManifest {
-  package: {version: string; name: string; 'default-run': string}
+  package: { version: string; name: string; 'default-run': string }
   bin: CargoManifestBin[]
 }
 
@@ -70,7 +70,7 @@ interface BuildOptions {
 async function buildProject(
   root: string,
   debug: boolean,
-  {configPath, distPath, iconPath, npmScript}: BuildOptions
+  { configPath, distPath, iconPath, npmScript }: BuildOptions
 ): Promise<string[]> {
   return new Promise<string>(resolve => {
     if (core.getInput('preferGlobal') === "true") {
@@ -82,7 +82,7 @@ async function buildProject(
         resolve(usesYarn(root) ? 'yarn tauri' : 'npx tauri')
       }
     } else {
-      execCommand('npm install -g tauri', {cwd: undefined}).then(() =>
+      execCommand('npm install -g tauri', { cwd: undefined }).then(() =>
         resolve('tauri')
       )
     }
@@ -147,7 +147,7 @@ async function buildProject(
       const args = debug ? ['--debug'] : []
       return execCommand(
         `${app.runner} build` + (args.length ? ` ${args.join(' ')}` : ''),
-        {cwd: root}
+        { cwd: root }
       )
         .then(() => {
           const appName = app.name
@@ -180,17 +180,27 @@ async function buildProject(
                 process.arch === 'x64'
                   ? 'amd64'
                   : process.arch === 'x32'
-                  ? 'i386'
-                  : process.arch
+                    ? 'i386'
+                    : process.arch
+
+              const oldAppImagePath = join(
+                artifactsPath,
+                `bundle/appimage/${appName}.AppImage`
+              );
+
+              const newAppImagePath = join(
+                artifactsPath,
+                `bundle/appimage/${appName}_${app.version}_${arch}.AppImage`
+              );
+
+              renameFileSync(oldAppImagePath, newAppImagePath);
+
               return [
                 join(
                   artifactsPath,
                   `bundle/deb/${appName}_${app.version}_${arch}.deb`
                 ),
-                join(
-                  artifactsPath,
-                  `bundle/appimage/${appName}_${app.version}_${arch}.AppImage`
-                )
+                newAppImagePath,
               ]
           }
         })

--- a/src/upload-release-assets.ts
+++ b/src/upload-release-assets.ts
@@ -1,4 +1,4 @@
-import {getOctokit, context} from '@actions/github'
+import { getOctokit, context } from '@actions/github'
 import fs from 'fs'
 import path from 'path'
 
@@ -6,6 +6,9 @@ export default async function uploadAssets(
   releaseId: number,
   assets: string[]
 ) {
+  ////////////////////////////////////////////
+  console.log('assets', JSON.stringify(assets))
+  ///////////////////////////////////////////////
   if (process.env.GITHUB_TOKEN === undefined) {
     throw new Error('GITHUB_TOKEN is required')
   }

--- a/src/upload-release-assets.ts
+++ b/src/upload-release-assets.ts
@@ -6,9 +6,6 @@ export default async function uploadAssets(
   releaseId: number,
   assets: string[]
 ) {
-  ////////////////////////////////////////////
-  console.log('assets', JSON.stringify(assets))
-  ///////////////////////////////////////////////
   if (process.env.GITHUB_TOKEN === undefined) {
     throw new Error('GITHUB_TOKEN is required')
   }


### PR DESCRIPTION
Currently, for linux only the deb artifact is pushed, not the AppImage one.
This is because the AppImage name has not the app version, nor the archictecture, meawhile the script tries to push the appImage formed with architecture and version in the name.

This pull request tries to resolve this issue.