### PR TITLE
feat: add support for building with vue cli

### DIFF
--- a/.changes/vue-cli-support.md
+++ b/.changes/vue-cli-support.md
@@ -1,0 +1,5 @@
+---
+"tauri-action": minor
+---
+
+If vue-cli-plugin-tauri is detected, the tauri:build command will be used.

--- a/.changes/vue-cli-support.md
+++ b/.changes/vue-cli-support.md
@@ -1,5 +1,5 @@
 ---
-"tauri-action": minor
+"action": minor
 ---
 
 If vue-cli-plugin-tauri is detected, the tauri:build command will be used.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y webkit2gtk-4.0
     - name: install app dependencies and build it
+    # If using the Vue CLI plugin, tauri:build will be run automatically by tauri-action
+    # and you can remove `&& yarn build` from this command
       run: yarn && yarn build
     - uses: tauri-apps/tauri-action@v0
       env:
@@ -149,6 +151,8 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y webkit2gtk-4.0
     - name: install app dependencies and build it
+    # If using the Vue CLI plugin, tauri:build will be run automatically by tauri-action
+    # and you can remove `&& yarn build` from this command
       run: yarn && yarn build
     - uses: tauri-apps/tauri-action@v0
       env:

--- a/dist/main.js
+++ b/dist/main.js
@@ -48,11 +48,12 @@ function getPackageJson(root) {
     }
     return null;
 }
-function hasTauriDependency(root) {
+function hasDependency(dependencyName, root) {
     const packageJson = getPackageJson(root);
     return (packageJson &&
-        ((packageJson.dependencies && packageJson.dependencies.tauri) ||
-            (packageJson.devDependencies && packageJson.devDependencies.tauri)));
+        ((packageJson.dependencies && packageJson.dependencies[dependencyName]) ||
+            (packageJson.devDependencies &&
+                packageJson.devDependencies[dependencyName])));
 }
 function usesYarn(root) {
     return fs_1.existsSync(path_1.join(root, 'yarn.lock'));
@@ -71,10 +72,10 @@ function execCommand(command, { cwd }) {
 function buildProject(root, debug, { configPath, distPath, iconPath, npmScript }) {
     return __awaiter(this, void 0, void 0, function* () {
         return new Promise(resolve => {
-            if (core.getInput('preferGlobal') === "true") {
+            if (core.getInput('preferGlobal') === 'true') {
                 resolve('tauri');
             }
-            else if (hasTauriDependency(root)) {
+            else if (hasDependency('tauri', root) || hasDependency('vue-cli-plugin-tauri', root)) {
                 if (npmScript) {
                     resolve(usesYarn(root) ? `yarn ${npmScript}` : `npm run ${npmScript}`);
                 }
@@ -134,7 +135,10 @@ function buildProject(root, debug, { configPath, distPath, iconPath, npmScript }
                 fs_1.writeFileSync(tauriConfPath, JSON.stringify(tauriConf));
             }
             const args = debug ? ['--debug'] : [];
-            return execCommand(`${app.runner} build` + (args.length ? ` ${args.join(' ')}` : ''), { cwd: root })
+            const buildCommand = hasDependency('vue-cli-plugin-tauri', root)
+                ? (usesYarn(root) ? 'yarn' : 'npm run') + ' tauri:build'
+                : `${app.runner} build`;
+            return execCommand(buildCommand + (args.length ? ` ${args.join(' ')}` : ''), { cwd: root })
                 .then(() => {
                 const appName = app.name;
                 const artifactsPath = path_1.join(root, `src-tauri/target/${debug ? 'debug' : 'release'}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -76,7 +76,7 @@ async function buildProject(
   return new Promise<string>(resolve => {
     if (core.getInput('preferGlobal') === 'true') {
       resolve('tauri')
-    } else if (hasDependency('tauri', root)) {
+    } else if (hasDependency('tauri', root) || hasDependency('vue-cli-plugin-tauri', root)) {
       if (npmScript) {
         resolve(usesYarn(root) ? `yarn ${npmScript}` : `npm run ${npmScript}`)
       } else {


### PR DESCRIPTION
If vue-cli-plugin-tauri is installed, it will run `yarn tauri:build` instead of `yarn tauri build`.