### PR TITLE
fix(core): use tar.gz for linux updater artifacts

### DIFF
--- a/.changes/appimage-update-file-ending.md
+++ b/.changes/appimage-update-file-ending.md
@@ -1,0 +1,6 @@
+---
+"@tauri-apps/action-core": patch
+"action": patch
+---
+
+Modify the action to look for .tar.gz instead of .zip for the Linux updater artifacts.

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -280,11 +280,11 @@ export async function buildProject(
                 ),
                 join(
                   artifactsPath,
-                  `bundle/appimage/${appName}_${app.version}_${arch}.AppImage.zip`
+                  `bundle/appimage/${appName}_${app.version}_${arch}.AppImage.tar.gz`
                 ),
                 join(
                   artifactsPath,
-                  `bundle/appimage/${appName}_${app.version}_${arch}.AppImage.zip.sig`
+                  `bundle/appimage/${appName}_${app.version}_${arch}.AppImage.tar.gz.sig`
                 )
               ]
           }


### PR DESCRIPTION
According to the [docs](https://tauri.studio/en/docs/usage/guides/updater#linux) and how the artifacts are generated by the bundler the file ending for linux should be is .tar.gz.