### PR TITLE
fix(action): Better alignment with updater artifacts

### DIFF
--- a/.changes/appimage-artifacts.md
+++ b/.changes/appimage-artifacts.md
@@ -1,0 +1,7 @@
+---
+"@tauri-apps/action-core": patch
+"action": patch
+---
+
+Linux: Upload AppImage updater artifacts if available.
+macOS: Replace `[AppName].app.tgz` to `[AppName].app.tar.gz` to align with updater artifacts.

--- a/packages/action/src/index.ts
+++ b/packages/action/src/index.ts
@@ -94,11 +94,13 @@ async function run(): Promise<void> {
       if (platform() === 'darwin') {
         let i = 0
         for (const artifact of artifacts) {
-          if (artifact.endsWith('.app')) {
-            await execCommand('tar', ['czf', `${artifact}.tgz`, artifact], {
+          // updater provide a .tar.gz, this will prevent duplicate and overwriting of
+          // signed archive
+          if (artifact.endsWith('.app') && !existsSync(`${artifact}.tar.gz`)) {
+            await execCommand('tar', ['czf', `${artifact}.tar.gz`, artifact], {
               cwd: undefined
             })
-            artifacts[i] += '.tgz'
+            artifacts[i] += '.tar.gz'
           }
           i++
         }

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -280,11 +280,11 @@ export async function buildProject(
                 ),
                 join(
                   artifactsPath,
-                  `bundle/appimage/${appName}_${app.version}_${arch}.AppImage.zip`
+                  `bundle/appimage/${appName}_${app.version}_${arch}.AppImage.tar.gz`
                 ),
                 join(
                   artifactsPath,
-                  `bundle/appimage/${appName}_${app.version}_${arch}.AppImage.zip.sig`
+                  `bundle/appimage/${appName}_${app.version}_${arch}.AppImage.tar.gz.sig`
                 )
               ]
           }


### PR DESCRIPTION
- Linux: Upload AppImage updater artifacts if available.
- macOS: Replace `[AppName].app.tgz` to `[AppName].app.tar.gz` to align with updater artifacts and prevent overwriting of signed artifacts.
