### PR TITLE
chore(readme): upgrade node-v to 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ jobs:
     - name: setup node
       uses: actions/setup-node@v1
       with:
-        node-version: 12
+        node-version: 16
     - name: install Rust stable
       uses: actions-rs/toolchain@v1
       with:
@@ -65,7 +65,7 @@ jobs:
     - name: setup node
       uses: actions/setup-node@v1
       with:
-        node-version: 12
+        node-version: 16
     - name: install Rust stable
       uses: actions-rs/toolchain@v1
       with:
@@ -107,7 +107,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 16
       - name: get version
         run: echo "PACKAGE_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
       - name: create release
@@ -134,7 +134,7 @@ jobs:
     - name: setup node
       uses: actions/setup-node@v1
       with:
-        node-version: 12
+        node-version: 16
     - name: install Rust stable
       uses: actions-rs/toolchain@v1
       with:


### PR DESCRIPTION
Tauri upgraded the node version they use to 16.  In their documentation they state they only support their most up to date versions, so readme github action files should upgrade to go along side.  Can be seen working at my [repo](https://github.com/bayswaterpc/owaagh)