### PR TITLE
fix(core): version parse error when referring to package.json

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -201,7 +201,8 @@ export function getInfo(root: string): Info {
       name = config.package.productName
       version = config.package.version
       if (config.package.version?.endsWith('package.json')) {
-        const contents = readFileSync(config.package.version).toString()
+        const packageJsonPath = join(tauriDir, config.package.version)
+        const contents = readFileSync(packageJsonPath).toString()
         version = JSON.parse(contents).version
       }
     }

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -200,6 +200,10 @@ export function getInfo(root: string): Info {
     if (config.package) {
       name = config.package.productName
       version = config.package.version
+      if (config.package.version?.endsWith('package.json')) {
+        const contents = readFileSync(config.package.version).toString()
+        version = JSON.parse(contents).version
+      }
     }
     if (!(name && version)) {
       const manifestPath = join(tauriDir, 'Cargo.toml')


### PR DESCRIPTION
Get the correct version if `package.version` is a path to a `package.json` file contaning the `version` field. #262