### PR TITLE
os name included in the executable name

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -403,11 +403,11 @@ export async function buildProject(
             return [
               join(
                 artifactsPath,
-                `bundle/dmg/${fileAppName}_${app.version}_${process.arch}.dmg`
+                `bundle/dmg/${fileAppName}_${app.version}_${process.arch}_macos.dmg`
               ),
-              join(artifactsPath, `bundle/macos/${fileAppName}.app`),
-              join(artifactsPath, `bundle/macos/${fileAppName}.app.tar.gz`),
-              join(artifactsPath, `bundle/macos/${fileAppName}.app.tar.gz.sig`),
+              join(artifactsPath, `bundle/macos/${fileAppName}_macos.app`),
+              join(artifactsPath, `bundle/macos/${fileAppName}_macos.app.tar.gz`),
+              join(artifactsPath, `bundle/macos/${fileAppName}_macos.app.tar.gz.sig`),
             ]
           } else if (platform() === 'win32') {
             // If multiple Wix languages are specified, multiple installers (.msi) will be made
@@ -425,19 +425,19 @@ export async function buildProject(
               artifacts.push(
                 join(
                   artifactsPath,
-                  `bundle/msi/${fileAppName}_${app.version}_${process.arch}_${lang}.msi`
+                  `bundle/msi/${fileAppName}_${app.version}_${process.arch}_${lang}_windows.msi`
                 )
               )
               artifacts.push(
                 join(
                   artifactsPath,
-                  `bundle/msi/${fileAppName}_${app.version}_${process.arch}_${lang}.msi.zip`
+                  `bundle/msi/${fileAppName}_${app.version}_${process.arch}_${lang}_windows.msi.zip`
                 )
               )
               artifacts.push(
                 join(
                   artifactsPath,
-                  `bundle/msi/${fileAppName}_${app.version}_${process.arch}_${lang}.msi.zip.sig`
+                  `bundle/msi/${fileAppName}_${app.version}_${process.arch}_${lang}_windows.msi.zip.sig`
                 )
               )
             })
@@ -452,19 +452,19 @@ export async function buildProject(
             return [
               join(
                 artifactsPath,
-                `bundle/deb/${fileAppName}_${app.version}_${arch}.deb`
+                `bundle/deb/${fileAppName}_${app.version}_${arch}_linux.deb`
               ),
               join(
                 artifactsPath,
-                `bundle/appimage/${fileAppName}_${app.version}_${arch}.AppImage`
+                `bundle/appimage/${fileAppName}_${app.version}_${arch}_linux.AppImage`
               ),
               join(
                 artifactsPath,
-                `bundle/appimage/${fileAppName}_${app.version}_${arch}.AppImage.tar.gz`
+                `bundle/appimage/${fileAppName}_${app.version}_${arch}_linux.AppImage.tar.gz`
               ),
               join(
                 artifactsPath,
-                `bundle/appimage/${fileAppName}_${app.version}_${arch}.AppImage.tar.gz.sig`
+                `bundle/appimage/${fileAppName}_${app.version}_${arch}_linux.AppImage.tar.gz.sig`
               ),
             ]
           }


### PR DESCRIPTION
We (the developers) know `msi` is for windows, `dmg` is for macos, etc...
However, if the application we are going to build will be for **regular users**, they are often getting confused about which file to download. 

So, including the targeted OS_NAME in the executable file would help a lot. And it wouldn't cause any problem for us the developers (aside from reading 1 more word). 

What do you guys think?

Note: I did not test the code below. Assumed it would work right away, since it is a trivial change.

