### PR TITLE
fix: fileAppName on Linux

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -389,7 +389,7 @@ export async function buildProject(
             fileAppName = fileAppName
               .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
               .replace(/([A-Z])([A-Z])(?=[a-z])/g, '$1-$2')
-              .replace(/ /g, '-')
+              .replace(/[ _]/g, '-')
               .toLowerCase()
           }
 


### PR DESCRIPTION
`productName` with `_` (underscore) did not result in kebab-case.