### PR TITLE
fix windows aarch64 bundle not found

### DIFF
--- a/.changes/fix-windows-aarch64-bundle.md
+++ b/.changes/fix-windows-aarch64-bundle.md
@@ -1,0 +1,5 @@
+---
+action: patch:bug
+---
+
+When building windows-aarch64, looking for x64 bundle.

--- a/.changes/fix-windows-aarch64-bundle.md
+++ b/.changes/fix-windows-aarch64-bundle.md
@@ -2,4 +2,4 @@
 action: patch:bug
 ---
 
-When building windows-aarch64, looking for x64 bundle.
+Fix detection of windows arm64 bundles.

--- a/src/build.ts
+++ b/src/build.ts
@@ -98,8 +98,6 @@ export async function buildProject(
       join(artifactsPath, `bundle/macos/${fileAppName}.app.tar.gz.sig`),
     ].map((path) => ({ path, arch }));
   } else if (targetInfo.platform === 'windows') {
-    // arch = arch.startsWith('i') ? 'x86' : 'x64';
-    // fix windows aarch64 bundle not found
     if (arch.startsWith('i')) {
       arch = 'x86';
     } else if (arch === 'aarch64') {

--- a/src/build.ts
+++ b/src/build.ts
@@ -98,7 +98,15 @@ export async function buildProject(
       join(artifactsPath, `bundle/macos/${fileAppName}.app.tar.gz.sig`),
     ].map((path) => ({ path, arch }));
   } else if (targetInfo.platform === 'windows') {
-    arch = arch.startsWith('i') ? 'x86' : 'x64';
+    // arch = arch.startsWith('i') ? 'x86' : 'x64';
+    // fix windows aarch64 bundle not found
+    if (arch.startsWith('i')) {
+      arch = 'x86';
+    } else if (arch === 'aarch64') {
+      arch = 'arm64';
+    } else {
+      arch = 'x64';
+    }
 
     // If multiple Wix languages are specified, multiple installers (.msi) will be made
     // The .zip and .sig are only generated for the first specified language


### PR DESCRIPTION
![image](https://github.com/tauri-apps/tauri-action/assets/35366425/5144dc37-3391-4a0c-912e-eaf022bf94b5)

When building windows-aarch64, looking for x64 bundle.