### PR TITLE
Add Tauri 2.0 Action Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,112 @@ jobs:
             })
 ```
 
+## Tauri 2.0 build action with Cargo
+
+Tauri 2.0 is not installed correctly unless a previous step installs the correct version. A step to install the 2.0 beta is required and a tauriScript variable is set for the action. There is also a requirement for ubuntu 22.04 to be used and webkitgtk upgraded to 4.1. I also had to use nodeJS and a [small script](https://github.com/H2-Technologies/multi-op-qso-logger/blob/main/version.js) to get the version from the tauri.conf.json file.
+
+```yml
+name: 'publish'
+
+# on a pull request and a push to the main or master branch
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+
+jobs:
+  create-release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-22.04
+    outputs:
+      release_id: ${{ steps.create-release.outputs.result }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: get version
+        run: echo "PACKAGE_VERSION=$(node version.js)" >> $GITHUB_ENV
+      - name: create release
+        id: create-release
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { data } = await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: `app-v${process.env.PACKAGE_VERSION}`,
+              name: `app-v${process.env.PACKAGE_VERSION}`,
+              body: 'Take a look at the assets to download and install this app.',
+              draft: true,
+              prerelease: false
+            })
+            return data.id
+
+  build-tauri:
+    needs: create-release
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [macos-latest, ubuntu-22.04, windows-latest]
+
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+      - name: install dependencies (ubuntu only)
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+      - name: Install Cargo Tauri for info
+        run: cargo install tauri-cli --version "^2.0.0-alpha"
+      - name: Tauri info
+        run: cargo tauri info
+      - uses: tauri-apps/tauri-action@v0
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          releaseId: ${{ needs.create-release.outputs.release_id }}
+          tauriScript: cargo tauri
+
+  publish-release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-22.04
+    needs: [create-release, build-tauri]
+
+    steps:
+      - name: publish release
+        id: publish-release
+        uses: actions/github-script@v6
+        env:
+          release_id: ${{ needs.create-release.outputs.release_id }}
+        with:
+          script: |
+            github.rest.repos.updateRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: process.env.release_id,
+              draft: false,
+              prerelease: false
+            })
+```
+
 ## Inputs
 
 ### Project Initialization


### PR DESCRIPTION
Tauri 2.0 requires webkitgtk 4.1 and ubuntu 22.04 should now be used. NPM projects have the CLI as part of the project where it needs to be installed with Cargo. We manually specified the Tauri version to be able to get Tauri 2.0. If you are signing the Tauri Release, you need to specify the keys and passwords in the Secrets setting in GitHub. 

Adding this action demonstrates the use on a Cargo project with the Tauri 2.0 Beta. This shows how the action would look with signed releases, updated OS's and packages, and a package version check from a small js script. #595  