### PR TITLE
fix(doc): fix incorrect workflow example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        - platform: 'macos-latest' # for Arm based macs (M1 and above).
-          args: '--target aarch64-apple-darwin'
-        - platform: 'macos-latest' # for Intel based macs.
-          args: '--target x86_64-apple-darwin'
-        - platform: 'ubuntu-22.04' # for Tauri v1 you could replace this with ubuntu-20.04.
-          args: ''
-        - platform: 'windows-latest'
-          args: ''
+        settings:
+          - platform: 'macos-latest' # for Arm based macs (M1 and above).
+            args: '--target aarch64-apple-darwin'
+          - platform: 'macos-latest' # for Intel based macs.
+            args: '--target x86_64-apple-darwin'
+          - platform: 'ubuntu-22.04' # for Tauri v1 you could replace this with ubuntu-20.04.
+            args: ''
+          - platform: 'windows-latest'
+            args: ''
 
     runs-on: ${{ matrix.settings.platform }}
     steps:

--- a/examples/publish-to-auto-release.yml
+++ b/examples/publish-to-auto-release.yml
@@ -15,14 +15,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        - platform: "macos-latest" # for Arm based macs (M1 and above).
-          args: "--target aarch64-apple-darwin"
-        - platform: "macos-latest" # for Intel based macs.
-          args: "--target x86_64-apple-darwin"
-        - platform: "ubuntu-22.04" # for Tauri v1 you could replace this with ubuntu-20.04.
-          args: ""
-        - platform: "windows-latest"
-          args: ""
+        settings:
+          - platform: "macos-latest" # for Arm based macs (M1 and above).
+            args: "--target aarch64-apple-darwin"
+          - platform: "macos-latest" # for Intel based macs.
+            args: "--target x86_64-apple-darwin"
+          - platform: "ubuntu-22.04" # for Tauri v1 you could replace this with ubuntu-20.04.
+            args: ""
+          - platform: "windows-latest"
+            args: ""
 
     runs-on: ${{ matrix.settings.platform }}
     steps:

--- a/examples/publish-to-manual-release.yml
+++ b/examples/publish-to-manual-release.yml
@@ -48,16 +48,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        - platform: "macos-latest" # for Arm based macs (M1 and above).
-          args: "--target aarch64-apple-darwin"
-        - platform: "macos-latest" # for Intel based macs.
-          args: "--target x86_64-apple-darwin"
-        - platform: "ubuntu-22.04" # for Tauri v1 you could replace this with ubuntu-20.04.
-          args: ""
-        - platform: "windows-latest"
-          args: ""
+        settings:
+          - platform: "macos-latest" # for Arm based macs (M1 and above).
+            args: "--target aarch64-apple-darwin"
+          - platform: "macos-latest" # for Intel based macs.
+            args: "--target x86_64-apple-darwin"
+          - platform: "ubuntu-22.04" # for Tauri v1 you could replace this with ubuntu-20.04.
+            args: ""
+          - platform: "windows-latest"
+            args: ""
 
-    runs-on: ${{ matrix.platform }}
+    runs-on: ${{ matrix.settings.platform }}
     steps:
       - uses: actions/checkout@v4
 

--- a/examples/test-build-only.yml
+++ b/examples/test-build-only.yml
@@ -9,14 +9,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        - platform: "macos-latest" # for Arm based macs (M1 and above).
-          args: "--target aarch64-apple-darwin"
-        - platform: "macos-latest" # for Intel based macs.
-          args: "--target x86_64-apple-darwin"
-        - platform: "ubuntu-22.04" # for Tauri v1 you could replace this with ubuntu-20.04.
-          args: ""
-        - platform: "windows-latest"
-          args: ""
+        settings:
+          - platform: "macos-latest" # for Arm based macs (M1 and above).
+            args: "--target aarch64-apple-darwin"
+          - platform: "macos-latest" # for Intel based macs.
+            args: "--target x86_64-apple-darwin"
+          - platform: "ubuntu-22.04" # for Tauri v1 you could replace this with ubuntu-20.04.
+            args: ""
+          - platform: "windows-latest"
+            args: ""
 
     runs-on: ${{ matrix.settings.platform }}
     steps:


### PR DESCRIPTION
## Description

This PR addresses two issues encountered while using the example workflow:

1. The example in the readme leads to an error "A sequence was not expected" due to the `settings` variable being missing. This PR fixes the example by adding the missing `settings` variable.
![Screenshot 2024-04-04 at 02 02 45](https://github.com/tauri-apps/tauri-action/assets/6448596/742cbf81-1997-447a-9296-d87c29ab0967)


~2. When building for ARM-based Mac, an error occurs due to the missing `aarch64-apple-darwin`. This PR resolves the error by adding an additional step to run `rustup target add aarch64-apple-darwin` during the build process.~
![Screenshot 2024-04-04 at 02 05 54](https://github.com/tauri-apps/tauri-action/assets/6448596/0620afa7-6323-47fc-bea7-779efd74bf93)


## Changes Made

- Added the missing `settings` variable to the example in the readme.
- ~Included an additional step to run `rustup target add aarch64-apple-darwin` for ARM-based Mac builds.~