### PR TITLE
docs: Add a workflow example for publishing Universal macOS app with signing certificate

### DIFF
--- a/examples/publish-to-auto-release-universal-macos-app-with-signing-certificate.yml
+++ b/examples/publish-to-auto-release-universal-macos-app-with-signing-certificate.yml
@@ -1,0 +1,92 @@
+name: "publish"
+
+on:
+  push:
+    branches:
+      - release
+
+# This is the example for publishing a Universal macOS app with a signing certificate.
+# On each push to the `release` branch it will create or update a GitHub release, build your app, and upload the artifacts to the release.
+
+jobs:
+  publish-tauri:
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # for Universal macOS builds (arm64 and x86_64)
+          - platform: 'macos-latest'
+            args: '--target universal-apple-darwin'
+
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+
+      - name: install frontend dependencies
+        run: yarn install # change this to npm, pnpm or bun depending on which one you use.
+
+      - name: import Apple Developer Certificate
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          echo $APPLE_CERTIFICATE | base64 --decode > certificate.p12
+          security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security set-keychain-settings -t 3600 -u build.keychain
+          security import certificate.p12 -k build.keychain -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" build.keychain
+          security find-identity -v -p codesigning build.keychain
+
+      - name: verify certificate
+        run: |
+          CERT_INFO=$(security find-identity -v -p codesigning build.keychain | grep "Developer ID Application")
+          CERT_ID=$(echo "$CERT_INFO" | awk -F'"' '{print $2}')
+          echo "CERT_ID=$CERT_ID" >> $GITHUB_ENV
+          echo "Certificate imported."
+
+      - name: read version and set env
+        run: | # use tauri.conf.json version as the tag
+          VERSION_TAG=v$(jq -r '.version' < src-tauri/tauri.conf.json)
+          echo "VERSION_TAG=$VERSION_TAG" >> $GITHUB_ENV
+
+      - name: build and publish
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ env.CERT_ID }}
+        with:
+          tagName: ${{ env.VERSION_TAG }}
+          releaseName: 'App ${{ env.VERSION_TAG }}'
+          releaseBody: 'See the assets to download this version and install.'
+          # releaseDraft: true # uncomment this line to create a draft release
+          includeDebug: true
+          args: ${{ matrix.args }}
+
+      - name: set release version tag
+        run: |
+          if git rev-parse "${{ env.VERSION_TAG }}" >/dev/null 2>&1; then echo "Tag ${{ env.VERSION_TAG }} already exists. Skipping tagging."
+          else echo "Tagging with version: ${{ env.VERSION_TAG }}"
+            git tag ${{ env.VERSION_TAG }}
+            git push origin ${{ env.VERSION_TAG }}
+          fi

--- a/examples/publish-to-auto-release-universal-macos-app-with-signing-certificate.yml
+++ b/examples/publish-to-auto-release-universal-macos-app-with-signing-certificate.yml
@@ -38,6 +38,7 @@ jobs:
         run: yarn install # change this to npm, pnpm or bun depending on which one you use.
 
       - name: import Apple Developer Certificate
+        # Prevents keychain from locking automatically for 3600 seconds.
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}

--- a/examples/publish-to-auto-release-universal-macos-app-with-signing-certificate.yml
+++ b/examples/publish-to-auto-release-universal-macos-app-with-signing-certificate.yml
@@ -59,11 +59,6 @@ jobs:
           echo "CERT_ID=$CERT_ID" >> $GITHUB_ENV
           echo "Certificate imported."
 
-      - name: read version and set env
-        run: | # use tauri.conf.json version as the tag
-          VERSION_TAG=v$(jq -r '.version' < src-tauri/tauri.conf.json)
-          echo "VERSION_TAG=$VERSION_TAG" >> $GITHUB_ENV
-
       - name: build and publish
         uses: tauri-apps/tauri-action@v0
         env:
@@ -76,17 +71,9 @@ jobs:
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           APPLE_SIGNING_IDENTITY: ${{ env.CERT_ID }}
         with:
-          tagName: ${{ env.VERSION_TAG }}
-          releaseName: 'App ${{ env.VERSION_TAG }}'
-          releaseBody: 'See the assets to download this version and install.'
-          # releaseDraft: true # uncomment this line to create a draft release
-          includeDebug: true
+          tagName: app-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version.
+          releaseName: "App v__VERSION__"
+          releaseBody: "See the assets to download this version and install."
+          releaseDraft: true
+          prerelease: false
           args: ${{ matrix.args }}
-
-      - name: set release version tag
-        run: |
-          if git rev-parse "${{ env.VERSION_TAG }}" >/dev/null 2>&1; then echo "Tag ${{ env.VERSION_TAG }} already exists. Skipping tagging."
-          else echo "Tagging with version: ${{ env.VERSION_TAG }}"
-            git tag ${{ env.VERSION_TAG }}
-            git push origin ${{ env.VERSION_TAG }}
-          fi


### PR DESCRIPTION
This workflow ensures that the app is properly signed and ready for distribution on macOS.
Users can start using the app right away since the signed .dmg has been released.  (Users can skip the hassle of allowing the app to run in "Privacy & Security" after downloading it. )

- sample: my CD result
https://github.com/8beeeaaat/tauri_distribution_sample/releases

This workflow creates or updates a GitHub release, builds the app, and uploads the artifacts to the release on each push to the `release` branch.
It includes steps for setting up the environment, importing the Apple Developer Certificate, and building and publishing the app using tauri-action.

- Imports the Apple Developer Certificate.
- Verifies the imported certificate.
- Prevents keychain from locking automatically for 3600 seconds. https://github.com/tauri-apps/tauri-action/issues/941