### PR TITLE
fix: Fix examples to use an existing tauri-action tag (v0) instead of v1.

### DIFF
--- a/examples/publish-to-auto-release-universal-macos-app-with-signing-certificate.yml
+++ b/examples/publish-to-auto-release-universal-macos-app-with-signing-certificate.yml
@@ -61,7 +61,7 @@ jobs:
           echo "Certificate imported."
 
       - name: build and publish
-        uses: tauri-apps/tauri-action@v1
+        uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           APPLE_ID: ${{ secrets.APPLE_ID }}

--- a/examples/publish-to-auto-release.yml
+++ b/examples/publish-to-auto-release.yml
@@ -49,7 +49,7 @@ jobs:
       - name: install frontend dependencies
         run: yarn install # change this to npm, pnpm or bun depending on which one you use.
 
-      - uses: tauri-apps/tauri-action@v1
+      - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/examples/publish-to-manual-release.yml
+++ b/examples/publish-to-manual-release.yml
@@ -82,7 +82,7 @@ jobs:
       - name: install frontend dependencies
         run: yarn install # change this to npm, pnpm or bun depending on which one you use.
 
-      - uses: tauri-apps/tauri-action@v1
+      - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/examples/test-build-only.yml
+++ b/examples/test-build-only.yml
@@ -44,7 +44,7 @@ jobs:
         run: yarn install # change this to npm, pnpm or bun depending on which one you use.
 
       # If tagName and releaseId are omitted tauri-action will only build the app and won't try to upload any assets.
-      - uses: tauri-apps/tauri-action@v1
+      - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Hi maintainers, thanks for the great action.
While reviewing the examples, I noticed they reference tauri-apps/tauri-action@v1, but the repository’s tags list only shows v0 tags (e.g., v0.6.1, v0.6, v0) and no v1 tag: https://github.com/tauri-apps/tauri-action/tags. This causes the example workflows to reference a non-existent tag, which will cause workflow failures.

<details>
<summary>Workflow Failure Details</summary>

<img width="1209" height="533" alt="image" src="https://github.com/user-attachments/assets/1213ae8f-074d-4c75-8cfa-22d9d73ffb52" />


</details>

This PR updates the examples to use an existing tag (v0). Please let me know if you’d prefer a different tag or version pin. Hopefully, I didn't get anything wrong. I'm always willing to help!